### PR TITLE
Ensure that Migrations Build via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,19 @@ jobs:
         npm run lint
         npm run build
 
+  build_contracts_1_1_migration:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+    - name: "Install Dependencies"
+      run: |
+        sudo apt-get update && sudo apt-get install build-essential git libusb-1.0-0 libusb-1.0-0-dev libudev-dev
+    - name: "Build and lint deploy scripts"
+      run: |
+        cd migrations/contracts-1.1
+        npm i
+
   notify_complete:
     runs-on: ubuntu-latest
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ migrations/*/src/config.ts
 migrations/*/deploy-data.json
 node_modules/
 smart_contracts/smartpy_out
+migrations/*/build

--- a/migrations/contracts-1.1/package-lock.json
+++ b/migrations/contracts-1.1/package-lock.json
@@ -16,6 +16,9 @@
         "@types/node": "^16.9.2",
         "bignumber.js": "^9.0.1",
         "conseiljs": "^5.0.8-3"
+      },
+      "devDependencies": {
+        "typescript": "^4.4.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -351,6 +354,18 @@
       "engines": {
         "node": ">=12.18.3",
         "npm": ">=6.14.6"
+      }
+    },
+    "node_modules/@tacoinfra/harbinger-lib/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@tacoinfra/tezos-kms": {
@@ -2585,9 +2600,9 @@
       ]
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3055,6 +3070,11 @@
             "moo": "0.5.0",
             "nearley": "2.19.1"
           }
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
         }
       }
     },
@@ -4815,9 +4835,9 @@
       "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ=="
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/migrations/contracts-1.1/package.json
+++ b/migrations/contracts-1.1/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "build": "tsc -d",
     "install-submodules": "cd ../../multisig-timelock/cli && rm -rf node_modules && npm i",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -18,5 +19,8 @@
     "@types/node": "^16.9.2",
     "bignumber.js": "^9.0.1",
     "conseiljs": "^5.0.8-3"
+  },
+  "devDependencies": {
+    "typescript": "^4.4.4"
   }
 }

--- a/migrations/contracts-1.1/src/crosscheck.ts
+++ b/migrations/contracts-1.1/src/crosscheck.ts
@@ -1,7 +1,13 @@
 import { initConseil, loadContract } from "./utils";
 import { initOracleLib, Utils } from "@tacoinfra/harbinger-lib";
+import { KeyStore } from "conseiljs";
 
-export default async function crosscheck(config: any) {
+type CrossCheckResult = {
+    keystore: KeyStore,
+    contractSources: object
+}
+
+export default async function crosscheck(config: any): Promise<CrossCheckResult> {
     console.log('>>> [1/4] Input params:')
     console.log(`Tezos Node: ${config.NODE_URL}`)
     console.log(`Indexer URL: ${config.BETTER_CALL_DEV_BASE_URL}`)

--- a/migrations/contracts-1.1/src/utils.ts
+++ b/migrations/contracts-1.1/src/utils.ts
@@ -78,7 +78,7 @@ export async function sendOperation(
             return result.hash
         }
 
-    } catch (e) {
+    } catch (e: any) {
         console.log('Caught exception, retrying...')
         console.log(e.message)
         console.error(e)
@@ -120,7 +120,7 @@ export async function deployContract(
             operationHash: result.hash,
             contractAddress: result.contractAddress || "ERR",
         }
-    } catch (e) {
+    } catch (e: any) {
         console.log('Caught exception, retrying...')
         console.error(e)
         debugger;
@@ -175,7 +175,7 @@ export const checkConfirmed = async (config: any, operationHash: string): Promis
 
             // If we've made it here without an error, then all tests have passed and the operation has confirmed.
             return
-        } catch (e) {
+        } catch (e: any) {
             // Something above didn't track - that's probably okay since the network sometimes runs slow.
             // Print the error and sleep for another block before trying again.
             console.log(`Caught exception while polling ${e}`)

--- a/migrations/contracts-1.1/tsconfig.json
+++ b/migrations/contracts-1.1/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "rootDir": "./",
+    "outDir": "build",
+    "target": "esnext",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "removeComments": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "src/*.ts"
+  ]
+}


### PR DESCRIPTION
Build `migrations/contracts-1.1` as part of CI. This verifies that our scripts our still buildable and runnable. 

Specifically:
- Add `tsconfig.json`, npm script for `build` and add `typescript` as a dep
- Fix a few errors `tsc` complained about 
- Add new CI step in workflow