### PR TITLE
[Contracts 1.2] Add Method to Zero out Dev and Stability Fund

### DIFF
--- a/migrations/contracts-1.2/src/config.sandbox.ts
+++ b/migrations/contracts-1.2/src/config.sandbox.ts
@@ -21,5 +21,5 @@ export const KOLIBRI_CONFIG: KolibriConfig = {
 export const MIGRATION_CONFIG = {
   // 5% Interest
   // See https://www.wolframalpha.com/input/?i=ln%281+%2B+0.05%29+%2F+%2860+*+24+*+365%29
-  initialInterestRate: new BigNumber('92827557400')
+  initialInterestRate: new BigNumber('000000000000928276')
 }

--- a/migrations/contracts-1.2/src/config.sandbox.ts
+++ b/migrations/contracts-1.2/src/config.sandbox.ts
@@ -21,5 +21,5 @@ export const KOLIBRI_CONFIG: KolibriConfig = {
 export const MIGRATION_CONFIG = {
   // 5% Interest
   // See https://www.wolframalpha.com/input/?i=ln%281+%2B+0.05%29+%2F+%2860+*+24+*+365%29
-  initialInterestRate: new BigNumber('000000000000928276')
+  initialInterestRate: new BigNumber('92827557400')
 }

--- a/smart_contracts/Makefile
+++ b/smart_contracts/Makefile
@@ -75,7 +75,7 @@ test-e2e:
 # Compile the Dev Fund
 compile-dev-fund:
 	$(SMART_PY_CLI) compile dev-fund.py $(OUT_DIR)
-	cp $(OUT_DIR)/dev-fund/step_000_cont_0_contract.tz dev-fund.tz
+	cp $(OUT_DIR)/dev-fund/step_000_cont_2_contract.tz dev-fund.tz
 	rm -rf $(OUT_DIR)
 
 # Compile the Minter

--- a/smart_contracts/compile.sh
+++ b/smart_contracts/compile.sh
@@ -45,9 +45,9 @@ function processContract {
     echo ">>> Done."
 
     echo ">>> [3 / 3] Copying Artifacts"
-    # Some contracts need to inherit or have other contrats, in which case they will be step_000_cont_1.
+    # Some contracts need to inherit or have other contracts, in which case they will be step_000_cont_1 or 2.
     # TODO(keefertaylor): This is pretty brittle. Consider if we should migrate to Makefile or find a better way.
-    cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_0_contract.tz" $CONTRACT_OUT || cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_1_contract.tz" $CONTRACT_OUT 
+    cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_0_contract.tz" $CONTRACT_OUT || cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_1_contract.tz" $CONTRACT_OUT || cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_2_contract.tz" $CONTRACT_OUT 
     echo ">>> Written to ${CONTRACT_OUT}"
 }
 

--- a/smart_contracts/dev-fund.py
+++ b/smart_contracts/dev-fund.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
         dummyContract = DummyContract.DummyContract()
         scenario += dummyContract
 
-        # WHEN send is calledb with less than the full amount
+        # WHEN send is called with less than the full amount
         sendAmount = sp.mutez(2)
         param = (sendAmount, dummyContract.address)
         scenario += fund.send(param).run(
@@ -266,7 +266,8 @@ if __name__ == "__main__":
         param = (balance, notGovernor)
         scenario += fund.send(param).run(
             sender = notGovernor,
-            valid = False
+            valid = False,
+            exception = Errors.NOT_GOVERNOR
         )    
 
     ################################################################
@@ -316,7 +317,8 @@ if __name__ == "__main__":
         notGovernor = Addresses.NULL_ADDRESS
         scenario += fund.sendAll(notGovernor).run(
             sender = notGovernor,
-            valid = False
+            valid = False,
+            exception = Errors.NOT_GOVERNOR
         )    
 
     ################################################################

--- a/smart_contracts/dev-fund.tz
+++ b/smart_contracts/dev-fund.tz
@@ -1,4 +1,4 @@
-parameter (or (or (unit %default) (or (pair %send mutez address) (pair %sendTokens nat address))) (or (address %setAdministratorContract) (or (option %setDelegate key_hash) (address %setGovernorContract))));
+parameter (or (or (unit %default) (or (pair %send mutez address) (address %sendAll))) (or (or (pair %sendTokens nat address) (address %setAdministratorContract)) (or (option %setDelegate key_hash) (address %setGovernorContract))));
 storage   (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %tokenContractAddress)));
 code
   {
@@ -48,6 +48,43 @@ code
                 CONS;       # list operation : @storage
               }
               {
+                SWAP;       # @storage : @parameter%sendAll
+                # == sendAll ==
+                # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendAll
+                DUP;        # @storage : @storage : @parameter%sendAll
+                DUG 2;      # @storage : @parameter%sendAll : @storage
+                GET 3;      # address : @parameter%sendAll : @storage
+                SENDER;     # @sender : address : @parameter%sendAll : @storage
+                COMPARE;    # int : @parameter%sendAll : @storage
+                EQ;         # bool : @parameter%sendAll : @storage
+                IF
+                  {}
+                  {
+                    PUSH int 4; # int : @parameter%sendAll : @storage
+                    FAILWITH;   # FAILED
+                  }; # @parameter%sendAll : @storage
+                # sp.send(params, sp.balance) # @parameter%sendAll : @storage
+                CONTRACT unit; # option (contract unit) : @storage
+                IF_NONE
+                  {
+                    UNIT;       # unit : @storage
+                    FAILWITH;   # FAILED
+                  }
+                  {}; # @some : @storage
+                NIL operation; # list operation : @some : @storage
+                SWAP;       # @some : list operation : @storage
+                BALANCE;    # @balance : @some : list operation : @storage
+                UNIT;       # unit : @balance : @some : list operation : @storage
+                TRANSFER_TOKENS; # operation : list operation : @storage
+                CONS;       # list operation : @storage
+              }; # list operation : @storage
+          }; # list operation : @storage
+      }
+      {
+        IF_LEFT
+          {
+            IF_LEFT
+              {
                 SWAP;       # @storage : @parameter%sendTokens
                 # == sendTokens ==
                 # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendTokens
@@ -82,30 +119,27 @@ code
                 PAIR 3;     # pair @self (pair address nat) : mutez : @some : list operation : @storage
                 TRANSFER_TOKENS; # operation : list operation : @storage
                 CONS;       # list operation : @storage
-              }; # list operation : @storage
-          }; # list operation : @storage
-      }
-      {
-        IF_LEFT
-          {
-            SWAP;       # @storage : @parameter%setAdministratorContract
-            # == setAdministratorContract ==
-            # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setAdministratorContract
-            DUP;        # @storage : @storage : @parameter%setAdministratorContract
-            DUG 2;      # @storage : @parameter%setAdministratorContract : @storage
-            GET 3;      # address : @parameter%setAdministratorContract : @storage
-            SENDER;     # @sender : address : @parameter%setAdministratorContract : @storage
-            COMPARE;    # int : @parameter%setAdministratorContract : @storage
-            EQ;         # bool : @parameter%setAdministratorContract : @storage
-            IF
-              {}
+              }
               {
-                PUSH int 4; # int : @parameter%setAdministratorContract : @storage
-                FAILWITH;   # FAILED
-              }; # @parameter%setAdministratorContract : @storage
-            # self.data.administratorContractAddress = params # @parameter%setAdministratorContract : @storage
-            UPDATE 1;   # @storage
-            NIL operation; # list operation : @storage
+                SWAP;       # @storage : @parameter%setAdministratorContract
+                # == setAdministratorContract ==
+                # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setAdministratorContract
+                DUP;        # @storage : @storage : @parameter%setAdministratorContract
+                DUG 2;      # @storage : @parameter%setAdministratorContract : @storage
+                GET 3;      # address : @parameter%setAdministratorContract : @storage
+                SENDER;     # @sender : address : @parameter%setAdministratorContract : @storage
+                COMPARE;    # int : @parameter%setAdministratorContract : @storage
+                EQ;         # bool : @parameter%setAdministratorContract : @storage
+                IF
+                  {}
+                  {
+                    PUSH int 4; # int : @parameter%setAdministratorContract : @storage
+                    FAILWITH;   # FAILED
+                  }; # @parameter%setAdministratorContract : @storage
+                # self.data.administratorContractAddress = params # @parameter%setAdministratorContract : @storage
+                UPDATE 1;   # @storage
+                NIL operation; # list operation : @storage
+              }; # list operation : @storage
           }
           {
             IF_LEFT

--- a/smart_contracts/stability-fund.py
+++ b/smart_contracts/stability-fund.py
@@ -27,7 +27,11 @@ class StabilityFundContract(DevFund.DevFundContract):
             administratorContractAddress = administratorContractAddress,
             tokenContractAddress = tokenContractAddress,
             ovenRegistryContractAddress = ovenRegistryContractAddress,
-            savingsAccountContractAddress = savingsAccountContractAddress
+            savingsAccountContractAddress = savingsAccountContractAddress,
+
+            # State machine
+            state= DevFund.IDLE,
+            sendAllTokens_destination = sp.none
         )
 
     ################################################################

--- a/smart_contracts/stability-fund.tz
+++ b/smart_contracts/stability-fund.tz
@@ -1,4 +1,4 @@
-parameter (or (or (or (nat %accrueInterest) (unit %default)) (or (address %liquidate) (or (pair %send mutez address) (pair %sendTokens nat address)))) (or (or (address %setAdministratorContract) (option %setDelegate key_hash)) (or (address %setGovernorContract) (or (address %setOvenRegistryContract) (address %setSavingsAccountContract)))));
+parameter (or (or (or (nat %accrueInterest) (unit %default)) (or (address %liquidate) (or (pair %send mutez address) (address %sendAll)))) (or (or (pair %sendTokens nat address) (or (address %setAdministratorContract) (option %setDelegate key_hash))) (or (address %setGovernorContract) (or (address %setOvenRegistryContract) (address %setSavingsAccountContract)))));
 storage   (pair (pair (address %administratorContractAddress) (address %governorContractAddress)) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))));
 code
   {
@@ -136,39 +136,34 @@ code
                     CONS;       # list operation : @storage
                   }
                   {
-                    SWAP;       # @storage : @parameter%sendTokens
-                    # == sendTokens ==
-                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendTokens
-                    DUP;        # @storage : @storage : @parameter%sendTokens
-                    DUG 2;      # @storage : @parameter%sendTokens : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%sendTokens : @storage
-                    CDR;        # address : @parameter%sendTokens : @storage
-                    SENDER;     # @sender : address : @parameter%sendTokens : @storage
-                    COMPARE;    # int : @parameter%sendTokens : @storage
-                    EQ;         # bool : @parameter%sendTokens : @storage
+                    SWAP;       # @storage : @parameter%sendAll
+                    # == sendAll ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendAll
+                    DUP;        # @storage : @storage : @parameter%sendAll
+                    DUG 2;      # @storage : @parameter%sendAll : @storage
+                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%sendAll : @storage
+                    CDR;        # address : @parameter%sendAll : @storage
+                    SENDER;     # @sender : address : @parameter%sendAll : @storage
+                    COMPARE;    # int : @parameter%sendAll : @storage
+                    EQ;         # bool : @parameter%sendAll : @storage
                     IF
                       {}
                       {
-                        PUSH int 4; # int : @parameter%sendTokens : @storage
+                        PUSH int 4; # int : @parameter%sendAll : @storage
                         FAILWITH;   # FAILED
-                      }; # @parameter%sendTokens : @storage
-                    # sp.transfer(sp.record(from_ = sp.self_address, to_ = sp.snd(params), value = sp.fst(params)), sp.tez(0), sp.contract(sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))), self.data.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%sendTokens : @storage
-                    NIL operation; # list operation : @parameter%sendTokens : @storage
-                    DUP 3;      # @storage : list operation : @parameter%sendTokens : @storage
-                    GET 6;      # address : list operation : @parameter%sendTokens : @storage
-                    CONTRACT %transfer (pair address (pair address nat)); # option (contract (pair address (pair address nat))) : list operation : @parameter%sendTokens : @storage
+                      }; # @parameter%sendAll : @storage
+                    # sp.send(params, sp.balance) # @parameter%sendAll : @storage
+                    CONTRACT unit; # option (contract unit) : @storage
                     IF_NONE
                       {
-                        UNIT;       # unit : list operation : @parameter%sendTokens : @storage
+                        UNIT;       # unit : @storage
                         FAILWITH;   # FAILED
                       }
-                      {}; # @some : list operation : @parameter%sendTokens : @storage
-                    PUSH mutez 0; # mutez : @some : list operation : @parameter%sendTokens : @storage
-                    DIG 3;      # @parameter%sendTokens : mutez : @some : list operation : @storage
-                    UNPAIR;     # nat : address : mutez : @some : list operation : @storage
-                    SWAP;       # address : nat : mutez : @some : list operation : @storage
-                    SELF_ADDRESS; # @self : address : nat : mutez : @some : list operation : @storage
-                    PAIR 3;     # pair @self (pair address nat) : mutez : @some : list operation : @storage
+                      {}; # @some : @storage
+                    NIL operation; # list operation : @some : @storage
+                    SWAP;       # @some : list operation : @storage
+                    BALANCE;    # @balance : @some : list operation : @storage
+                    UNIT;       # unit : @balance : @some : list operation : @storage
                     TRANSFER_TOKENS; # operation : list operation : @storage
                     CONS;       # list operation : @storage
                   }; # list operation : @storage
@@ -180,53 +175,93 @@ code
           {
             IF_LEFT
               {
-                SWAP;       # @storage : @parameter%setAdministratorContract
-                # == setAdministratorContract ==
-                # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setAdministratorContract
-                DUP;        # @storage : @storage : @parameter%setAdministratorContract
-                DUG 2;      # @storage : @parameter%setAdministratorContract : @storage
-                CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setAdministratorContract : @storage
-                CDR;        # address : @parameter%setAdministratorContract : @storage
-                SENDER;     # @sender : address : @parameter%setAdministratorContract : @storage
-                COMPARE;    # int : @parameter%setAdministratorContract : @storage
-                EQ;         # bool : @parameter%setAdministratorContract : @storage
+                SWAP;       # @storage : @parameter%sendTokens
+                # == sendTokens ==
+                # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendTokens
+                DUP;        # @storage : @storage : @parameter%sendTokens
+                DUG 2;      # @storage : @parameter%sendTokens : @storage
+                CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%sendTokens : @storage
+                CDR;        # address : @parameter%sendTokens : @storage
+                SENDER;     # @sender : address : @parameter%sendTokens : @storage
+                COMPARE;    # int : @parameter%sendTokens : @storage
+                EQ;         # bool : @parameter%sendTokens : @storage
                 IF
                   {}
                   {
-                    PUSH int 4; # int : @parameter%setAdministratorContract : @storage
+                    PUSH int 4; # int : @parameter%sendTokens : @storage
                     FAILWITH;   # FAILED
-                  }; # @parameter%setAdministratorContract : @storage
-                SWAP;       # @storage : @parameter%setAdministratorContract
-                # self.data.administratorContractAddress = params # @storage : @parameter%setAdministratorContract
-                UNPAIR;     # pair (address %administratorContractAddress) (address %governorContractAddress) : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setAdministratorContract
-                CDR;        # address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setAdministratorContract
-                DIG 2;      # @parameter%setAdministratorContract : address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                PAIR;       # pair @parameter%setAdministratorContract address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                PAIR;       # pair (pair @parameter%setAdministratorContract address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-                NIL operation; # list operation : pair (pair @parameter%setAdministratorContract address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
+                  }; # @parameter%sendTokens : @storage
+                # sp.transfer(sp.record(from_ = sp.self_address, to_ = sp.snd(params), value = sp.fst(params)), sp.tez(0), sp.contract(sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))), self.data.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%sendTokens : @storage
+                NIL operation; # list operation : @parameter%sendTokens : @storage
+                DUP 3;      # @storage : list operation : @parameter%sendTokens : @storage
+                GET 6;      # address : list operation : @parameter%sendTokens : @storage
+                CONTRACT %transfer (pair address (pair address nat)); # option (contract (pair address (pair address nat))) : list operation : @parameter%sendTokens : @storage
+                IF_NONE
+                  {
+                    UNIT;       # unit : list operation : @parameter%sendTokens : @storage
+                    FAILWITH;   # FAILED
+                  }
+                  {}; # @some : list operation : @parameter%sendTokens : @storage
+                PUSH mutez 0; # mutez : @some : list operation : @parameter%sendTokens : @storage
+                DIG 3;      # @parameter%sendTokens : mutez : @some : list operation : @storage
+                UNPAIR;     # nat : address : mutez : @some : list operation : @storage
+                SWAP;       # address : nat : mutez : @some : list operation : @storage
+                SELF_ADDRESS; # @self : address : nat : mutez : @some : list operation : @storage
+                PAIR 3;     # pair @self (pair address nat) : mutez : @some : list operation : @storage
+                TRANSFER_TOKENS; # operation : list operation : @storage
+                CONS;       # list operation : @storage
               }
               {
-                SWAP;       # @storage : @parameter%setDelegate
-                # == setDelegate ==
-                # sp.verify(sp.sender == self.data.administratorContractAddress, 8) # @storage : @parameter%setDelegate
-                DUP;        # @storage : @storage : @parameter%setDelegate
-                DUG 2;      # @storage : @parameter%setDelegate : @storage
-                CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setDelegate : @storage
-                CAR;        # address : @parameter%setDelegate : @storage
-                SENDER;     # @sender : address : @parameter%setDelegate : @storage
-                COMPARE;    # int : @parameter%setDelegate : @storage
-                EQ;         # bool : @parameter%setDelegate : @storage
-                IF
-                  {}
+                IF_LEFT
                   {
-                    PUSH int 8; # int : @parameter%setDelegate : @storage
-                    FAILWITH;   # FAILED
-                  }; # @parameter%setDelegate : @storage
-                # sp.set_delegate(params) # @parameter%setDelegate : @storage
-                SET_DELEGATE; # operation : @storage
-                NIL operation; # list operation : operation : @storage
-                SWAP;       # operation : list operation : @storage
-                CONS;       # list operation : @storage
+                    SWAP;       # @storage : @parameter%setAdministratorContract
+                    # == setAdministratorContract ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setAdministratorContract
+                    DUP;        # @storage : @storage : @parameter%setAdministratorContract
+                    DUG 2;      # @storage : @parameter%setAdministratorContract : @storage
+                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setAdministratorContract : @storage
+                    CDR;        # address : @parameter%setAdministratorContract : @storage
+                    SENDER;     # @sender : address : @parameter%setAdministratorContract : @storage
+                    COMPARE;    # int : @parameter%setAdministratorContract : @storage
+                    EQ;         # bool : @parameter%setAdministratorContract : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 4; # int : @parameter%setAdministratorContract : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%setAdministratorContract : @storage
+                    SWAP;       # @storage : @parameter%setAdministratorContract
+                    # self.data.administratorContractAddress = params # @storage : @parameter%setAdministratorContract
+                    UNPAIR;     # pair (address %administratorContractAddress) (address %governorContractAddress) : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setAdministratorContract
+                    CDR;        # address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setAdministratorContract
+                    DIG 2;      # @parameter%setAdministratorContract : address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
+                    PAIR;       # pair @parameter%setAdministratorContract address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
+                    PAIR;       # pair (pair @parameter%setAdministratorContract address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
+                    NIL operation; # list operation : pair (pair @parameter%setAdministratorContract address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
+                  }
+                  {
+                    SWAP;       # @storage : @parameter%setDelegate
+                    # == setDelegate ==
+                    # sp.verify(sp.sender == self.data.administratorContractAddress, 8) # @storage : @parameter%setDelegate
+                    DUP;        # @storage : @storage : @parameter%setDelegate
+                    DUG 2;      # @storage : @parameter%setDelegate : @storage
+                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setDelegate : @storage
+                    CAR;        # address : @parameter%setDelegate : @storage
+                    SENDER;     # @sender : address : @parameter%setDelegate : @storage
+                    COMPARE;    # int : @parameter%setDelegate : @storage
+                    EQ;         # bool : @parameter%setDelegate : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 8; # int : @parameter%setDelegate : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%setDelegate : @storage
+                    # sp.set_delegate(params) # @parameter%setDelegate : @storage
+                    SET_DELEGATE; # operation : @storage
+                    NIL operation; # list operation : operation : @storage
+                    SWAP;       # operation : list operation : @storage
+                    CONS;       # list operation : @storage
+                  }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
               }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
           }
           {

--- a/smart_contracts/stability-fund.tz
+++ b/smart_contracts/stability-fund.tz
@@ -1,5 +1,5 @@
-parameter (or (or (or (nat %accrueInterest) (unit %default)) (or (address %liquidate) (or (pair %send mutez address) (address %sendAll)))) (or (or (pair %sendTokens nat address) (or (address %setAdministratorContract) (option %setDelegate key_hash))) (or (address %setGovernorContract) (or (address %setOvenRegistryContract) (address %setSavingsAccountContract)))));
-storage   (pair (pair (address %administratorContractAddress) (address %governorContractAddress)) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))));
+parameter (or (or (or (nat %accrueInterest) (or (unit %default) (address %liquidate))) (or (or (pair %rescueFA12 (address %tokenContractAddress) (pair (nat %amount) (address %destination))) (pair %rescueFA2 (address %tokenContractAddress) (pair (nat %tokenId) (pair (nat %amount) (address %destination))))) (or (pair %send mutez address) (address %sendAll)))) (or (or (or (address %sendAllTokens) (nat %sendAllTokens_callback)) (or (pair %sendTokens nat address) (address %setAdministratorContract))) (or (or (option %setDelegate key_hash) (address %setGovernorContract)) (or (address %setOvenRegistryContract) (address %setSavingsAccountContract)))));
+storage   (pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))));
 code
   {
     UNPAIR;     # @parameter : @storage
@@ -14,7 +14,8 @@ code
                 # sp.verify(sp.sender == self.data.savingsAccountContractAddress, 27) # @storage : @parameter%accrueInterest
                 DUP;        # @storage : @storage : @parameter%accrueInterest
                 DUG 2;      # @storage : @parameter%accrueInterest : @storage
-                GET 5;      # address : @parameter%accrueInterest : @storage
+                GET 3;      # pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address) : @parameter%accrueInterest : @storage
+                CAR;        # address : @parameter%accrueInterest : @storage
                 SENDER;     # @sender : address : @parameter%accrueInterest : @storage
                 COMPARE;    # int : @parameter%accrueInterest : @storage
                 EQ;         # bool : @parameter%accrueInterest : @storage
@@ -38,65 +39,161 @@ code
                 PUSH mutez 0; # mutez : @some : list operation : @parameter%accrueInterest : @storage
                 DIG 3;      # @parameter%accrueInterest : mutez : @some : list operation : @storage
                 DUP 5;      # @storage : @parameter%accrueInterest : mutez : @some : list operation : @storage
-                GET 5;      # address : @parameter%accrueInterest : mutez : @some : list operation : @storage
+                GET 3;      # pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address) : @parameter%accrueInterest : mutez : @some : list operation : @storage
+                CAR;        # address : @parameter%accrueInterest : mutez : @some : list operation : @storage
                 SELF_ADDRESS; # @self : address : @parameter%accrueInterest : mutez : @some : list operation : @storage
                 PAIR 3;     # pair @self (pair address @parameter%accrueInterest) : mutez : @some : list operation : @storage
                 TRANSFER_TOKENS; # operation : list operation : @storage
                 CONS;       # list operation : @storage
               }
               {
-                DROP;       # @storage
-                # == default == # @storage
-                NIL operation; # list operation : @storage
+                IF_LEFT
+                  {
+                    DROP;       # @storage
+                    # == default == # @storage
+                    NIL operation; # list operation : @storage
+                  }
+                  {
+                    SWAP;       # @storage : @parameter%liquidate
+                    # == liquidate ==
+                    # sp.verify(sp.sender == self.data.administratorContractAddress, 8) # @storage : @parameter%liquidate
+                    DUP;        # @storage : @storage : @parameter%liquidate
+                    DUG 2;      # @storage : @parameter%liquidate : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%liquidate : @storage
+                    CAR;        # address : @parameter%liquidate : @storage
+                    SENDER;     # @sender : address : @parameter%liquidate : @storage
+                    COMPARE;    # int : @parameter%liquidate : @storage
+                    EQ;         # bool : @parameter%liquidate : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 8; # int : @parameter%liquidate : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%liquidate : @storage
+                    # sp.transfer(params, sp.tez(0), sp.contract(sp.TAddress, self.data.ovenRegistryContractAddress, entry_point='isOven').open_some()) # @parameter%liquidate : @storage
+                    NIL operation; # list operation : @parameter%liquidate : @storage
+                    DUP 3;      # @storage : list operation : @parameter%liquidate : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation : @parameter%liquidate : @storage
+                    GET 4;      # address : list operation : @parameter%liquidate : @storage
+                    CONTRACT %isOven address; # option (contract address) : list operation : @parameter%liquidate : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : list operation : @parameter%liquidate : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : list operation : @parameter%liquidate : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @parameter%liquidate : @storage
+                    DUP 4;      # @parameter%liquidate : mutez : @some : list operation : @parameter%liquidate : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @parameter%liquidate : @storage
+                    CONS;       # list operation : @parameter%liquidate : @storage
+                    SWAP;       # @parameter%liquidate : list operation : @storage
+                    # sp.send(params, sp.tez(0)) # @parameter%liquidate : list operation : @storage
+                    CONTRACT %liquidate unit; # option (contract unit) : list operation : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : list operation : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : list operation : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @storage
+                    UNIT;       # unit : mutez : @some : list operation : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @storage
+                    CONS;       # list operation : @storage
+                  }; # list operation : @storage
               }; # list operation : @storage
           }
           {
             IF_LEFT
               {
-                SWAP;       # @storage : @parameter%liquidate
-                # == liquidate ==
-                # sp.verify(sp.sender == self.data.administratorContractAddress, 8) # @storage : @parameter%liquidate
-                DUP;        # @storage : @storage : @parameter%liquidate
-                DUG 2;      # @storage : @parameter%liquidate : @storage
-                CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%liquidate : @storage
-                CAR;        # address : @parameter%liquidate : @storage
-                SENDER;     # @sender : address : @parameter%liquidate : @storage
-                COMPARE;    # int : @parameter%liquidate : @storage
-                EQ;         # bool : @parameter%liquidate : @storage
-                IF
-                  {}
+                IF_LEFT
                   {
-                    PUSH int 8; # int : @parameter%liquidate : @storage
-                    FAILWITH;   # FAILED
-                  }; # @parameter%liquidate : @storage
-                # sp.transfer(params, sp.tez(0), sp.contract(sp.TAddress, self.data.ovenRegistryContractAddress, entry_point='isOven').open_some()) # @parameter%liquidate : @storage
-                NIL operation; # list operation : @parameter%liquidate : @storage
-                DUP 3;      # @storage : list operation : @parameter%liquidate : @storage
-                GET 3;      # address : list operation : @parameter%liquidate : @storage
-                CONTRACT %isOven address; # option (contract address) : list operation : @parameter%liquidate : @storage
-                IF_NONE
-                  {
-                    UNIT;       # unit : list operation : @parameter%liquidate : @storage
-                    FAILWITH;   # FAILED
+                    SWAP;       # @storage : @parameter%rescueFA12
+                    # == rescueFA12 ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%rescueFA12
+                    DUP;        # @storage : @storage : @parameter%rescueFA12
+                    DUG 2;      # @storage : @parameter%rescueFA12 : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%rescueFA12 : @storage
+                    GET 3;      # address : @parameter%rescueFA12 : @storage
+                    SENDER;     # @sender : address : @parameter%rescueFA12 : @storage
+                    COMPARE;    # int : @parameter%rescueFA12 : @storage
+                    EQ;         # bool : @parameter%rescueFA12 : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 4; # int : @parameter%rescueFA12 : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%rescueFA12 : @storage
+                    # sp.transfer(sp.record(from_ = sp.self_address, to_ = params.destination, value = params.amount), sp.tez(0), sp.contract(sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))), params.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%rescueFA12 : @storage
+                    DUP;        # @parameter%rescueFA12 : @parameter%rescueFA12 : @storage
+                    CAR;        # address : @parameter%rescueFA12 : @storage
+                    CONTRACT %transfer (pair address (pair address nat)); # option (contract (pair address (pair address nat))) : @parameter%rescueFA12 : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : @parameter%rescueFA12 : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : @parameter%rescueFA12 : @storage
+                    NIL operation; # list operation : @some : @parameter%rescueFA12 : @storage
+                    SWAP;       # @some : list operation : @parameter%rescueFA12 : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @parameter%rescueFA12 : @storage
+                    DIG 3;      # @parameter%rescueFA12 : mutez : @some : list operation : @storage
+                    DUP;        # @parameter%rescueFA12 : @parameter%rescueFA12 : mutez : @some : list operation : @storage
+                    GET 3;      # nat : @parameter%rescueFA12 : mutez : @some : list operation : @storage
+                    SWAP;       # @parameter%rescueFA12 : nat : mutez : @some : list operation : @storage
+                    GET 4;      # address : nat : mutez : @some : list operation : @storage
+                    SELF_ADDRESS; # @self : address : nat : mutez : @some : list operation : @storage
+                    PAIR 3;     # pair @self (pair address nat) : mutez : @some : list operation : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @storage
+                    CONS;       # list operation : @storage
                   }
-                  {}; # @some : list operation : @parameter%liquidate : @storage
-                PUSH mutez 0; # mutez : @some : list operation : @parameter%liquidate : @storage
-                DUP 4;      # @parameter%liquidate : mutez : @some : list operation : @parameter%liquidate : @storage
-                TRANSFER_TOKENS; # operation : list operation : @parameter%liquidate : @storage
-                CONS;       # list operation : @parameter%liquidate : @storage
-                SWAP;       # @parameter%liquidate : list operation : @storage
-                # sp.send(params, sp.tez(0)) # @parameter%liquidate : list operation : @storage
-                CONTRACT %liquidate unit; # option (contract unit) : list operation : @storage
-                IF_NONE
                   {
-                    UNIT;       # unit : list operation : @storage
-                    FAILWITH;   # FAILED
-                  }
-                  {}; # @some : list operation : @storage
-                PUSH mutez 0; # mutez : @some : list operation : @storage
-                UNIT;       # unit : mutez : @some : list operation : @storage
-                TRANSFER_TOKENS; # operation : list operation : @storage
-                CONS;       # list operation : @storage
+                    SWAP;       # @storage : @parameter%rescueFA2
+                    # == rescueFA2 ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%rescueFA2
+                    DUP;        # @storage : @storage : @parameter%rescueFA2
+                    DUG 2;      # @storage : @parameter%rescueFA2 : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%rescueFA2 : @storage
+                    GET 3;      # address : @parameter%rescueFA2 : @storage
+                    SENDER;     # @sender : address : @parameter%rescueFA2 : @storage
+                    COMPARE;    # int : @parameter%rescueFA2 : @storage
+                    EQ;         # bool : @parameter%rescueFA2 : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 4; # int : @parameter%rescueFA2 : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%rescueFA2 : @storage
+                    # sp.transfer(sp.list([sp.record(from_ = sp.self_address, txs = sp.list([sp.record(to_ = params.destination, token_id = params.tokenId, amount = params.amount)]))]), sp.tez(0), sp.contract(sp.TList(sp.TRecord(from_ = sp.TAddress, txs = sp.TList(sp.TRecord(amount = sp.TNat, to_ = sp.TAddress, token_id = sp.TNat).layout(("to_", ("token_id", "amount"))))).layout(("from_", "txs"))), params.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%rescueFA2 : @storage
+                    DUP;        # @parameter%rescueFA2 : @parameter%rescueFA2 : @storage
+                    CAR;        # address : @parameter%rescueFA2 : @storage
+                    CONTRACT %transfer (list (pair address (list (pair address (pair nat nat))))); # option (contract (list (pair address (list (pair address (pair nat nat)))))) : @parameter%rescueFA2 : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : @parameter%rescueFA2 : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : @parameter%rescueFA2 : @storage
+                    NIL operation; # list operation : @some : @parameter%rescueFA2 : @storage
+                    SWAP;       # @some : list operation : @parameter%rescueFA2 : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @parameter%rescueFA2 : @storage
+                    NIL (pair address (list (pair address (pair nat nat)))); # list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @parameter%rescueFA2 : @storage
+                    NIL (pair address (pair nat nat)); # list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @parameter%rescueFA2 : @storage
+                    DIG 5;      # @parameter%rescueFA2 : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    DUP;        # @parameter%rescueFA2 : @parameter%rescueFA2 : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    GET 5;      # nat : @parameter%rescueFA2 : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    SWAP;       # @parameter%rescueFA2 : nat : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    DUP;        # @parameter%rescueFA2 : @parameter%rescueFA2 : nat : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    GET 3;      # nat : @parameter%rescueFA2 : nat : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    SWAP;       # @parameter%rescueFA2 : nat : nat : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    GET 6;      # address : nat : nat : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    PAIR 3;     # pair address (pair nat nat) : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    CONS;       # list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    SELF_ADDRESS; # @self : list (pair address (pair nat nat)) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    PAIR;       # pair @self (list (pair address (pair nat nat))) : list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    CONS;       # list (pair address (list (pair address (pair nat nat)))) : mutez : @some : list operation : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @storage
+                    CONS;       # list operation : @storage
+                  }; # list operation : @storage
               }
               {
                 IF_LEFT
@@ -106,8 +203,8 @@ code
                     # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%send
                     DUP;        # @storage : @storage : @parameter%send
                     DUG 2;      # @storage : @parameter%send : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%send : @storage
-                    CDR;        # address : @parameter%send : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%send : @storage
+                    GET 3;      # address : @parameter%send : @storage
                     SENDER;     # @sender : address : @parameter%send : @storage
                     COMPARE;    # int : @parameter%send : @storage
                     EQ;         # bool : @parameter%send : @storage
@@ -141,8 +238,8 @@ code
                     # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendAll
                     DUP;        # @storage : @storage : @parameter%sendAll
                     DUG 2;      # @storage : @parameter%sendAll : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%sendAll : @storage
-                    CDR;        # address : @parameter%sendAll : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%sendAll : @storage
+                    GET 3;      # address : @parameter%sendAll : @storage
                     SENDER;     # @sender : address : @parameter%sendAll : @storage
                     COMPARE;    # int : @parameter%sendAll : @storage
                     EQ;         # bool : @parameter%sendAll : @storage
@@ -175,52 +272,190 @@ code
           {
             IF_LEFT
               {
-                SWAP;       # @storage : @parameter%sendTokens
-                # == sendTokens ==
-                # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendTokens
-                DUP;        # @storage : @storage : @parameter%sendTokens
-                DUG 2;      # @storage : @parameter%sendTokens : @storage
-                CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%sendTokens : @storage
-                CDR;        # address : @parameter%sendTokens : @storage
-                SENDER;     # @sender : address : @parameter%sendTokens : @storage
-                COMPARE;    # int : @parameter%sendTokens : @storage
-                EQ;         # bool : @parameter%sendTokens : @storage
-                IF
-                  {}
+                IF_LEFT
                   {
-                    PUSH int 4; # int : @parameter%sendTokens : @storage
-                    FAILWITH;   # FAILED
-                  }; # @parameter%sendTokens : @storage
-                # sp.transfer(sp.record(from_ = sp.self_address, to_ = sp.snd(params), value = sp.fst(params)), sp.tez(0), sp.contract(sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))), self.data.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%sendTokens : @storage
-                NIL operation; # list operation : @parameter%sendTokens : @storage
-                DUP 3;      # @storage : list operation : @parameter%sendTokens : @storage
-                GET 6;      # address : list operation : @parameter%sendTokens : @storage
-                CONTRACT %transfer (pair address (pair address nat)); # option (contract (pair address (pair address nat))) : list operation : @parameter%sendTokens : @storage
-                IF_NONE
-                  {
-                    UNIT;       # unit : list operation : @parameter%sendTokens : @storage
-                    FAILWITH;   # FAILED
+                    SWAP;       # @storage : @parameter%sendAllTokens
+                    # == sendAllTokens ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendAllTokens
+                    DUP;        # @storage : @storage : @parameter%sendAllTokens
+                    DUG 2;      # @storage : @parameter%sendAllTokens : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%sendAllTokens : @storage
+                    GET 3;      # address : @parameter%sendAllTokens : @storage
+                    SENDER;     # @sender : address : @parameter%sendAllTokens : @storage
+                    COMPARE;    # int : @parameter%sendAllTokens : @storage
+                    EQ;         # bool : @parameter%sendAllTokens : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 4; # int : @parameter%sendAllTokens : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%sendAllTokens : @storage
+                    # sp.verify(self.data.state == 0, 12) # @parameter%sendAllTokens : @storage
+                    PUSH int 0; # int : @parameter%sendAllTokens : @storage
+                    DUP 3;      # @storage : int : @parameter%sendAllTokens : @storage
+                    GET 5;      # int : int : @parameter%sendAllTokens : @storage
+                    COMPARE;    # int : @parameter%sendAllTokens : @storage
+                    EQ;         # bool : @parameter%sendAllTokens : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 12; # int : @parameter%sendAllTokens : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%sendAllTokens : @storage
+                    # sp.transfer((sp.self_address, sp.self_entry_point('sendAllTokens_callback')), sp.tez(0), sp.contract(sp.TPair(sp.TAddress, sp.TContract(sp.TNat)), self.data.tokenContractAddress, entry_point='getBalance').open_some()) # @parameter%sendAllTokens : @storage
+                    NIL operation; # list operation : @parameter%sendAllTokens : @storage
+                    DUP 3;      # @storage : list operation : @parameter%sendAllTokens : @storage
+                    GET 6;      # address : list operation : @parameter%sendAllTokens : @storage
+                    CONTRACT %getBalance (pair address (contract nat)); # option (contract (pair address (contract nat))) : list operation : @parameter%sendAllTokens : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : list operation : @parameter%sendAllTokens : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : list operation : @parameter%sendAllTokens : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @parameter%sendAllTokens : @storage
+                    SELF %sendAllTokens_callback; # @self : mutez : @some : list operation : @parameter%sendAllTokens : @storage
+                    SELF_ADDRESS; # @self : @self : mutez : @some : list operation : @parameter%sendAllTokens : @storage
+                    PAIR;       # pair @self @self : mutez : @some : list operation : @parameter%sendAllTokens : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @parameter%sendAllTokens : @storage
+                    CONS;       # list operation : @parameter%sendAllTokens : @storage
+                    # self.data.state = 1 # list operation : @parameter%sendAllTokens : @storage
+                    DIG 2;      # @storage : list operation : @parameter%sendAllTokens
+                    PUSH int 1; # int : @storage : list operation : @parameter%sendAllTokens
+                    UPDATE 5;   # @storage : list operation : @parameter%sendAllTokens
+                    # self.data.sendAllTokens_destination = sp.some(params) # @storage : list operation : @parameter%sendAllTokens
+                    UNPAIR;     # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : list operation : @parameter%sendAllTokens
+                    SWAP;       # pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation : @parameter%sendAllTokens
+                    UNPAIR;     # pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address) : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation : @parameter%sendAllTokens
+                    CAR;        # address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation : @parameter%sendAllTokens
+                    DIG 4;      # @parameter%sendAllTokens : address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    SOME;       # option address : address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    SWAP;       # address : option address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    PAIR;       # pair address (option address) : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    PAIR;       # pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    SWAP;       # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)) : list operation
+                    PAIR;       # pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress))) : list operation
+                    SWAP;       # list operation : pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
                   }
-                  {}; # @some : list operation : @parameter%sendTokens : @storage
-                PUSH mutez 0; # mutez : @some : list operation : @parameter%sendTokens : @storage
-                DIG 3;      # @parameter%sendTokens : mutez : @some : list operation : @storage
-                UNPAIR;     # nat : address : mutez : @some : list operation : @storage
-                SWAP;       # address : nat : mutez : @some : list operation : @storage
-                SELF_ADDRESS; # @self : address : nat : mutez : @some : list operation : @storage
-                PAIR 3;     # pair @self (pair address nat) : mutez : @some : list operation : @storage
-                TRANSFER_TOKENS; # operation : list operation : @storage
-                CONS;       # list operation : @storage
+                  {
+                    SWAP;       # @storage : @parameter%sendAllTokens_callback
+                    # == sendAllTokens_callback ==
+                    # sp.verify(sp.sender == self.data.tokenContractAddress, 28) # @storage : @parameter%sendAllTokens_callback
+                    DUP;        # @storage : @storage : @parameter%sendAllTokens_callback
+                    DUG 2;      # @storage : @parameter%sendAllTokens_callback : @storage
+                    GET 6;      # address : @parameter%sendAllTokens_callback : @storage
+                    SENDER;     # @sender : address : @parameter%sendAllTokens_callback : @storage
+                    COMPARE;    # int : @parameter%sendAllTokens_callback : @storage
+                    EQ;         # bool : @parameter%sendAllTokens_callback : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 28; # int : @parameter%sendAllTokens_callback : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%sendAllTokens_callback : @storage
+                    # sp.verify(self.data.state == 1, 12) # @parameter%sendAllTokens_callback : @storage
+                    PUSH int 1; # int : @parameter%sendAllTokens_callback : @storage
+                    DUP 3;      # @storage : int : @parameter%sendAllTokens_callback : @storage
+                    GET 5;      # int : int : @parameter%sendAllTokens_callback : @storage
+                    COMPARE;    # int : @parameter%sendAllTokens_callback : @storage
+                    EQ;         # bool : @parameter%sendAllTokens_callback : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 12; # int : @parameter%sendAllTokens_callback : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%sendAllTokens_callback : @storage
+                    # sp.transfer(sp.record(from_ = sp.self_address, to_ = self.data.sendAllTokens_destination.open_some(), value = params), sp.tez(0), sp.contract(sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))), self.data.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%sendAllTokens_callback : @storage
+                    NIL operation; # list operation : @parameter%sendAllTokens_callback : @storage
+                    DUP 3;      # @storage : list operation : @parameter%sendAllTokens_callback : @storage
+                    GET 6;      # address : list operation : @parameter%sendAllTokens_callback : @storage
+                    CONTRACT %transfer (pair address (pair address nat)); # option (contract (pair address (pair address nat))) : list operation : @parameter%sendAllTokens_callback : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : list operation : @parameter%sendAllTokens_callback : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : list operation : @parameter%sendAllTokens_callback : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @parameter%sendAllTokens_callback : @storage
+                    DIG 3;      # @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                    DUP 5;      # @storage : @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                    GET 3;      # pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address) : @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                    CDR;        # option address : @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                    SELF_ADDRESS; # @self : @some : @parameter%sendAllTokens_callback : mutez : @some : list operation : @storage
+                    PAIR 3;     # pair @self (pair @some @parameter%sendAllTokens_callback) : mutez : @some : list operation : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @storage
+                    CONS;       # list operation : @storage
+                    SWAP;       # @storage : list operation
+                    # self.data.state = 0 # @storage : list operation
+                    PUSH int 0; # int : @storage : list operation
+                    UPDATE 5;   # @storage : list operation
+                    # self.data.sendAllTokens_destination = sp.none # @storage : list operation
+                    UNPAIR;     # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : list operation
+                    SWAP;       # pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    UNPAIR;     # pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address) : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    CAR;        # address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    NONE address; # option address : address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    SWAP;       # address : option address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    PAIR;       # pair address (option address) : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    PAIR;       # pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : list operation
+                    SWAP;       # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)) : list operation
+                    PAIR;       # pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress))) : list operation
+                    SWAP;       # list operation : pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+                  }; # list operation : pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
               }
               {
                 IF_LEFT
+                  {
+                    SWAP;       # @storage : @parameter%sendTokens
+                    # == sendTokens ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%sendTokens
+                    DUP;        # @storage : @storage : @parameter%sendTokens
+                    DUG 2;      # @storage : @parameter%sendTokens : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%sendTokens : @storage
+                    GET 3;      # address : @parameter%sendTokens : @storage
+                    SENDER;     # @sender : address : @parameter%sendTokens : @storage
+                    COMPARE;    # int : @parameter%sendTokens : @storage
+                    EQ;         # bool : @parameter%sendTokens : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 4; # int : @parameter%sendTokens : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%sendTokens : @storage
+                    # sp.transfer(sp.record(from_ = sp.self_address, to_ = sp.snd(params), value = sp.fst(params)), sp.tez(0), sp.contract(sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))), self.data.tokenContractAddress, entry_point='transfer').open_some()) # @parameter%sendTokens : @storage
+                    NIL operation; # list operation : @parameter%sendTokens : @storage
+                    DUP 3;      # @storage : list operation : @parameter%sendTokens : @storage
+                    GET 6;      # address : list operation : @parameter%sendTokens : @storage
+                    CONTRACT %transfer (pair address (pair address nat)); # option (contract (pair address (pair address nat))) : list operation : @parameter%sendTokens : @storage
+                    IF_NONE
+                      {
+                        UNIT;       # unit : list operation : @parameter%sendTokens : @storage
+                        FAILWITH;   # FAILED
+                      }
+                      {}; # @some : list operation : @parameter%sendTokens : @storage
+                    PUSH mutez 0; # mutez : @some : list operation : @parameter%sendTokens : @storage
+                    DIG 3;      # @parameter%sendTokens : mutez : @some : list operation : @storage
+                    UNPAIR;     # nat : address : mutez : @some : list operation : @storage
+                    SWAP;       # address : nat : mutez : @some : list operation : @storage
+                    SELF_ADDRESS; # @self : address : nat : mutez : @some : list operation : @storage
+                    PAIR 3;     # pair @self (pair address nat) : mutez : @some : list operation : @storage
+                    TRANSFER_TOKENS; # operation : list operation : @storage
+                    CONS;       # list operation : @storage
+                  }
                   {
                     SWAP;       # @storage : @parameter%setAdministratorContract
                     # == setAdministratorContract ==
                     # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setAdministratorContract
                     DUP;        # @storage : @storage : @parameter%setAdministratorContract
                     DUG 2;      # @storage : @parameter%setAdministratorContract : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setAdministratorContract : @storage
-                    CDR;        # address : @parameter%setAdministratorContract : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setAdministratorContract : @storage
+                    GET 3;      # address : @parameter%setAdministratorContract : @storage
                     SENDER;     # @sender : address : @parameter%setAdministratorContract : @storage
                     COMPARE;    # int : @parameter%setAdministratorContract : @storage
                     EQ;         # bool : @parameter%setAdministratorContract : @storage
@@ -232,20 +467,26 @@ code
                       }; # @parameter%setAdministratorContract : @storage
                     SWAP;       # @storage : @parameter%setAdministratorContract
                     # self.data.administratorContractAddress = params # @storage : @parameter%setAdministratorContract
-                    UNPAIR;     # pair (address %administratorContractAddress) (address %governorContractAddress) : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setAdministratorContract
-                    CDR;        # address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setAdministratorContract
-                    DIG 2;      # @parameter%setAdministratorContract : address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                    PAIR;       # pair @parameter%setAdministratorContract address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                    PAIR;       # pair (pair @parameter%setAdministratorContract address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-                    NIL operation; # list operation : pair (pair @parameter%setAdministratorContract address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-                  }
+                    UNPAIR;     # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setAdministratorContract
+                    CDR;        # pair (address %governorContractAddress) (address %ovenRegistryContractAddress) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setAdministratorContract
+                    DIG 2;      # @parameter%setAdministratorContract : pair (address %governorContractAddress) (address %ovenRegistryContractAddress) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair @parameter%setAdministratorContract (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair (pair @parameter%setAdministratorContract (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
+                    NIL operation; # list operation : pair (pair @parameter%setAdministratorContract (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
+                  }; # list operation : pair (pair address (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
+              }; # list operation : pair (pair address (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+          }
+          {
+            IF_LEFT
+              {
+                IF_LEFT
                   {
                     SWAP;       # @storage : @parameter%setDelegate
                     # == setDelegate ==
                     # sp.verify(sp.sender == self.data.administratorContractAddress, 8) # @storage : @parameter%setDelegate
                     DUP;        # @storage : @storage : @parameter%setDelegate
                     DUG 2;      # @storage : @parameter%setDelegate : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setDelegate : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setDelegate : @storage
                     CAR;        # address : @parameter%setDelegate : @storage
                     SENDER;     # @sender : address : @parameter%setDelegate : @storage
                     COMPARE;    # int : @parameter%setDelegate : @storage
@@ -261,36 +502,37 @@ code
                     NIL operation; # list operation : operation : @storage
                     SWAP;       # operation : list operation : @storage
                     CONS;       # list operation : @storage
-                  }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-              }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-          }
-          {
-            IF_LEFT
-              {
-                SWAP;       # @storage : @parameter%setGovernorContract
-                # == setGovernorContract ==
-                # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setGovernorContract
-                DUP;        # @storage : @storage : @parameter%setGovernorContract
-                DUG 2;      # @storage : @parameter%setGovernorContract : @storage
-                CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setGovernorContract : @storage
-                CDR;        # address : @parameter%setGovernorContract : @storage
-                SENDER;     # @sender : address : @parameter%setGovernorContract : @storage
-                COMPARE;    # int : @parameter%setGovernorContract : @storage
-                EQ;         # bool : @parameter%setGovernorContract : @storage
-                IF
-                  {}
+                  }
                   {
-                    PUSH int 4; # int : @parameter%setGovernorContract : @storage
-                    FAILWITH;   # FAILED
-                  }; # @parameter%setGovernorContract : @storage
-                SWAP;       # @storage : @parameter%setGovernorContract
-                # self.data.governorContractAddress = params # @storage : @parameter%setGovernorContract
-                UNPAIR;     # pair (address %administratorContractAddress) (address %governorContractAddress) : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setGovernorContract
-                CAR;        # address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)) : @parameter%setGovernorContract
-                DIG 2;      # @parameter%setGovernorContract : address : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                SWAP;       # address : @parameter%setGovernorContract : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                PAIR;       # pair address @parameter%setGovernorContract : pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))
-                PAIR;       # pair (pair address @parameter%setGovernorContract) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
+                    SWAP;       # @storage : @parameter%setGovernorContract
+                    # == setGovernorContract ==
+                    # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setGovernorContract
+                    DUP;        # @storage : @storage : @parameter%setGovernorContract
+                    DUG 2;      # @storage : @parameter%setGovernorContract : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setGovernorContract : @storage
+                    GET 3;      # address : @parameter%setGovernorContract : @storage
+                    SENDER;     # @sender : address : @parameter%setGovernorContract : @storage
+                    COMPARE;    # int : @parameter%setGovernorContract : @storage
+                    EQ;         # bool : @parameter%setGovernorContract : @storage
+                    IF
+                      {}
+                      {
+                        PUSH int 4; # int : @parameter%setGovernorContract : @storage
+                        FAILWITH;   # FAILED
+                      }; # @parameter%setGovernorContract : @storage
+                    SWAP;       # @storage : @parameter%setGovernorContract
+                    # self.data.governorContractAddress = params # @storage : @parameter%setGovernorContract
+                    UNPAIR;     # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setGovernorContract
+                    UNPAIR;     # address : pair (address %governorContractAddress) (address %ovenRegistryContractAddress) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setGovernorContract
+                    SWAP;       # pair (address %governorContractAddress) (address %ovenRegistryContractAddress) : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setGovernorContract
+                    CDR;        # address : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setGovernorContract
+                    DIG 3;      # @parameter%setGovernorContract : address : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair @parameter%setGovernorContract address : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    SWAP;       # address : pair @parameter%setGovernorContract address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair address (pair @parameter%setGovernorContract address) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair (pair address (pair @parameter%setGovernorContract address)) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
+                    NIL operation; # list operation : pair (pair address (pair @parameter%setGovernorContract address)) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
+                  }; # list operation : pair (pair address (pair address address)) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
               }
               {
                 IF_LEFT
@@ -300,8 +542,8 @@ code
                     # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setOvenRegistryContract
                     DUP;        # @storage : @storage : @parameter%setOvenRegistryContract
                     DUG 2;      # @storage : @parameter%setOvenRegistryContract : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setOvenRegistryContract : @storage
-                    CDR;        # address : @parameter%setOvenRegistryContract : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setOvenRegistryContract : @storage
+                    GET 3;      # address : @parameter%setOvenRegistryContract : @storage
                     SENDER;     # @sender : address : @parameter%setOvenRegistryContract : @storage
                     COMPARE;    # int : @parameter%setOvenRegistryContract : @storage
                     EQ;         # bool : @parameter%setOvenRegistryContract : @storage
@@ -311,8 +553,18 @@ code
                         PUSH int 4; # int : @parameter%setOvenRegistryContract : @storage
                         FAILWITH;   # FAILED
                       }; # @parameter%setOvenRegistryContract : @storage
-                    # self.data.ovenRegistryContractAddress = params # @parameter%setOvenRegistryContract : @storage
-                    UPDATE 3;   # @storage
+                    SWAP;       # @storage : @parameter%setOvenRegistryContract
+                    # self.data.ovenRegistryContractAddress = params # @storage : @parameter%setOvenRegistryContract
+                    UNPAIR;     # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setOvenRegistryContract
+                    UNPAIR;     # address : pair (address %governorContractAddress) (address %ovenRegistryContractAddress) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setOvenRegistryContract
+                    SWAP;       # pair (address %governorContractAddress) (address %ovenRegistryContractAddress) : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setOvenRegistryContract
+                    CAR;        # address : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setOvenRegistryContract
+                    DIG 3;      # @parameter%setOvenRegistryContract : address : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    SWAP;       # address : @parameter%setOvenRegistryContract : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair address @parameter%setOvenRegistryContract : address : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    SWAP;       # address : pair address @parameter%setOvenRegistryContract : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair address (pair address @parameter%setOvenRegistryContract) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair (pair address (pair address @parameter%setOvenRegistryContract)) (pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)))
                   }
                   {
                     SWAP;       # @storage : @parameter%setSavingsAccountContract
@@ -320,8 +572,8 @@ code
                     # sp.verify(sp.sender == self.data.governorContractAddress, 4) # @storage : @parameter%setSavingsAccountContract
                     DUP;        # @storage : @storage : @parameter%setSavingsAccountContract
                     DUG 2;      # @storage : @parameter%setSavingsAccountContract : @storage
-                    CAR;        # pair (address %administratorContractAddress) (address %governorContractAddress) : @parameter%setSavingsAccountContract : @storage
-                    CDR;        # address : @parameter%setSavingsAccountContract : @storage
+                    CAR;        # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setSavingsAccountContract : @storage
+                    GET 3;      # address : @parameter%setSavingsAccountContract : @storage
                     SENDER;     # @sender : address : @parameter%setSavingsAccountContract : @storage
                     COMPARE;    # int : @parameter%setSavingsAccountContract : @storage
                     EQ;         # bool : @parameter%setSavingsAccountContract : @storage
@@ -331,18 +583,27 @@ code
                         PUSH int 4; # int : @parameter%setSavingsAccountContract : @storage
                         FAILWITH;   # FAILED
                       }; # @parameter%setSavingsAccountContract : @storage
-                    # self.data.savingsAccountContractAddress = params # @parameter%setSavingsAccountContract : @storage
-                    UPDATE 5;   # @storage
-                  }; # @storage
-              }; # pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-            NIL operation; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-          }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-      }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-    NIL operation; # list operation : list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-    SWAP;       # list operation : list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
+                    SWAP;       # @storage : @parameter%setSavingsAccountContract
+                    # self.data.savingsAccountContractAddress = params # @storage : @parameter%setSavingsAccountContract
+                    UNPAIR;     # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : @parameter%setSavingsAccountContract
+                    SWAP;       # pair (pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address)) (pair (int %state) (address %tokenContractAddress)) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setSavingsAccountContract
+                    UNPAIR;     # pair (address %savingsAccountContractAddress) (option %sendAllTokens_destination address) : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setSavingsAccountContract
+                    CDR;        # option address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : @parameter%setSavingsAccountContract
+                    DIG 3;      # @parameter%setSavingsAccountContract : option address : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))
+                    PAIR;       # pair @parameter%setSavingsAccountContract (option address) : pair (int %state) (address %tokenContractAddress) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))
+                    PAIR;       # pair (pair @parameter%setSavingsAccountContract (option address)) (pair (int %state) (address %tokenContractAddress)) : pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))
+                    SWAP;       # pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress)) : pair (pair @parameter%setSavingsAccountContract (option address)) (pair (int %state) (address %tokenContractAddress))
+                    PAIR;       # pair (pair (address %administratorContractAddress) (pair (address %governorContractAddress) (address %ovenRegistryContractAddress))) (pair (pair @parameter%setSavingsAccountContract (option address)) (pair (int %state) (address %tokenContractAddress)))
+                  }; # pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+                NIL operation; # list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+              }; # list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+          }; # list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+      }; # list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+    NIL operation; # list operation : list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+    SWAP;       # list operation : list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
     ITER
       {
-        CONS;       # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-      }; # list operation : pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress)))
-    PAIR;       # pair (list operation) (pair (pair address address) (pair (address %ovenRegistryContractAddress) (pair (address %savingsAccountContractAddress) (address %tokenContractAddress))))
+        CONS;       # list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+      }; # list operation : pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress)))
+    PAIR;       # pair (list operation) (pair (pair address (pair address address)) (pair (pair address (option address)) (pair (int %state) (address %tokenContractAddress))))
   };

--- a/smart_contracts/test-helpers/fa12.py
+++ b/smart_contracts/test-helpers/fa12.py
@@ -1,0 +1,452 @@
+# Copied verbatim from SmartPy's templates on Nov 22, 2021
+
+# Fungible Assets - FA12
+# Inspired by https://gitlab.com/tzip/tzip/blob/master/A/FA1.2.md
+
+import smartpy as sp
+
+
+# The metadata below is just an example, it serves as a base,
+# the contents are used to build the metadata JSON that users
+# can copy and upload to IPFS.
+TZIP16_Metadata_Base = {
+    "name"          : "SmartPy FA1.2 Token Template",
+    "description"   : "Example Template for an FA1.2 Contract from SmartPy",
+    "authors"       : [
+        "SmartPy Dev Team <email@domain.com>"
+    ],
+    "homepage"      : "https://smartpy.io",
+    "interfaces"    : [
+        "TZIP-007-2021-04-17",
+        "TZIP-016-2021-04-17"
+    ],
+}
+
+# A collection of error messages used in the contract.
+class FA12_Error:
+    def make(s): return ("FA1.2_" + s)
+
+    NotAdmin                        = make("NotAdmin")
+    InsufficientBalance             = make("InsufficientBalance")
+    UnsafeAllowanceChange           = make("UnsafeAllowanceChange")
+    Paused                          = make("Paused")
+    NotAllowed                      = make("NotAllowed")
+
+
+##
+## ## Meta-Programming Configuration
+##
+## The `FA12_config` class holds the meta-programming configuration.
+##
+class FA12_config:
+    def __init__(
+        self,
+        support_upgradable_metadata         = False,
+        use_token_metadata_offchain_view    = True,
+    ):
+        self.support_upgradable_metadata = support_upgradable_metadata
+        # Whether the contract metadata can be upgradable or not.
+        # When True a new entrypoint `change_metadata` will be added.
+
+        self.use_token_metadata_offchain_view = use_token_metadata_offchain_view
+        # Include offchain view for accessing the token metadata (requires TZIP-016 contract metadata)
+
+class FA12_common:
+    def normalize_metadata(self, metadata):
+        """
+            Helper function to build metadata JSON (string => bytes).
+        """
+        for key in metadata:
+            metadata[key] = sp.utils.bytes_of_string(metadata[key])
+
+        return metadata
+
+class FA12_core(sp.Contract, FA12_common):
+    def __init__(self, config, **extra_storage):
+        self.config = config
+
+        self.init(
+            balances = sp.big_map(tvalue = sp.TRecord(approvals = sp.TMap(sp.TAddress, sp.TNat), balance = sp.TNat)),
+            totalSupply = 0,
+            **extra_storage
+        )
+
+    @sp.entry_point
+    def transfer(self, params):
+        sp.set_type(params, sp.TRecord(from_ = sp.TAddress, to_ = sp.TAddress, value = sp.TNat).layout(("from_ as from", ("to_ as to", "value"))))
+        sp.verify(self.is_administrator(sp.sender) |
+            (~self.is_paused() &
+                ((params.from_ == sp.sender) |
+                 (self.data.balances[params.from_].approvals[sp.sender] >= params.value))), FA12_Error.NotAllowed)
+        self.addAddressIfNecessary(params.from_)
+        self.addAddressIfNecessary(params.to_)
+        sp.verify(self.data.balances[params.from_].balance >= params.value, FA12_Error.InsufficientBalance)
+        self.data.balances[params.from_].balance = sp.as_nat(self.data.balances[params.from_].balance - params.value)
+        self.data.balances[params.to_].balance += params.value
+        sp.if (params.from_ != sp.sender) & (~self.is_administrator(sp.sender)):
+            self.data.balances[params.from_].approvals[sp.sender] = sp.as_nat(self.data.balances[params.from_].approvals[sp.sender] - params.value)
+
+    @sp.entry_point
+    def approve(self, params):
+        sp.set_type(params, sp.TRecord(spender = sp.TAddress, value = sp.TNat).layout(("spender", "value")))
+        self.addAddressIfNecessary(sp.sender)
+        sp.verify(~self.is_paused(), FA12_Error.Paused)
+        alreadyApproved = self.data.balances[sp.sender].approvals.get(params.spender, 0)
+        sp.verify((alreadyApproved == 0) | (params.value == 0), FA12_Error.UnsafeAllowanceChange)
+        self.data.balances[sp.sender].approvals[params.spender] = params.value
+
+    def addAddressIfNecessary(self, address):
+        sp.if ~ self.data.balances.contains(address):
+            self.data.balances[address] = sp.record(balance = 0, approvals = {})
+
+    @sp.utils.view(sp.TNat)
+    def getBalance(self, params):
+        sp.if self.data.balances.contains(params):
+            sp.result(self.data.balances[params].balance)
+        sp.else:
+            sp.result(sp.nat(0))
+
+    @sp.utils.view(sp.TNat)
+    def getAllowance(self, params):
+        sp.if self.data.balances.contains(params.owner):
+            sp.result(self.data.balances[params.owner].approvals.get(params.spender, 0))
+        sp.else:
+            sp.result(sp.nat(0))
+
+    @sp.utils.view(sp.TNat)
+    def getTotalSupply(self, params):
+        sp.set_type(params, sp.TUnit)
+        sp.result(self.data.totalSupply)
+
+    # this is not part of the standard but can be supported through inheritance.
+    def is_paused(self):
+        return sp.bool(False)
+
+    # this is not part of the standard but can be supported through inheritance.
+    def is_administrator(self, sender):
+        return sp.bool(False)
+
+class FA12_mint_burn(FA12_core):
+    @sp.entry_point
+    def mint(self, params):
+        sp.set_type(params, sp.TRecord(address = sp.TAddress, value = sp.TNat))
+        sp.verify(self.is_administrator(sp.sender), FA12_Error.NotAdmin)
+        self.addAddressIfNecessary(params.address)
+        self.data.balances[params.address].balance += params.value
+        self.data.totalSupply += params.value
+
+    @sp.entry_point
+    def burn(self, params):
+        sp.set_type(params, sp.TRecord(address = sp.TAddress, value = sp.TNat))
+        sp.verify(self.is_administrator(sp.sender), FA12_Error.NotAdmin)
+        sp.verify(self.data.balances[params.address].balance >= params.value, FA12_Error.InsufficientBalance)
+        self.data.balances[params.address].balance = sp.as_nat(self.data.balances[params.address].balance - params.value)
+        self.data.totalSupply = sp.as_nat(self.data.totalSupply - params.value)
+
+class FA12_administrator(FA12_core):
+    def is_administrator(self, sender):
+        return sender == self.data.administrator
+
+    @sp.entry_point
+    def setAdministrator(self, params):
+        sp.set_type(params, sp.TAddress)
+        sp.verify(self.is_administrator(sp.sender), FA12_Error.NotAdmin)
+        self.data.administrator = params
+
+    @sp.utils.view(sp.TAddress)
+    def getAdministrator(self, params):
+        sp.set_type(params, sp.TUnit)
+        sp.result(self.data.administrator)
+
+class FA12_pause(FA12_core):
+    def is_paused(self):
+        return self.data.paused
+
+    @sp.entry_point
+    def setPause(self, params):
+        sp.set_type(params, sp.TBool)
+        sp.verify(self.is_administrator(sp.sender), FA12_Error.NotAdmin)
+        self.data.paused = params
+
+class FA12_token_metadata(FA12_core):
+    """
+        SPEC: https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-12/tzip-12.md#token-metadata
+
+        Token-specific metadata is stored/presented as a Michelson value of type (map string bytes).
+
+        A few of the keys are reserved and predefined:
+
+        >>    ""          : Should correspond to a TZIP-016 URI which points to a JSON representation of the token
+                            metadata.
+
+        >>    "name"      : Should be a UTF-8 string giving a “display name” to the token.
+
+        >>    "symbol"    : Should be a UTF-8 string for the short identifier of the token (e.g. XTZ, EUR, …).
+
+        >>    "decimals"  : Should be an integer (converted to a UTF-8 string in decimal) which defines the position of                   the decimal point in token balances for displaypurposes.
+    """
+    def set_token_metadata(self, metadata):
+        """
+            Store the token_metadata values in a big-map annotated %token_metadata
+            of type (big_map nat (pair (nat %token_id) (map %token_info string bytes))).
+        """
+        self.update_initial_storage(
+            token_metadata = sp.big_map(
+                {
+                    0: sp.record(token_id = 0, token_info = self.normalize_metadata(metadata))
+                },
+                tkey = sp.TNat,
+                tvalue = sp.TRecord(token_id = sp.TNat, token_info = sp.TMap(sp.TString, sp.TBytes))
+            )
+        )
+
+class FA12_contract_metadata(FA12_core):
+    """
+        SPEC: https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-16/tzip-16.md
+
+        This class offers utilities to define and set TZIP-016 contract metadata.
+    """
+    def generate_tzip16_metadata(self):
+        views = []
+
+        def token_metadata(self, token_id):
+            """
+                This method will become an offchain view if the contract uses TZIP-016 metadata
+                and the config `use_token_metadata_offchain_view` is set to TRUE.
+
+                Return the token-metadata URI for the given token. (token_id must be 0)
+
+                For a reference implementation, dynamic-views seem to be the
+                most flexible choice.
+            """
+            sp.set_type(token_id, sp.TNat)
+            sp.result(self.data.token_metadata[token_id])
+
+        if self.usingTokenMetadata and self.config.use_token_metadata_offchain_view:
+            self.token_metadata = sp.offchain_view(pure = True, doc = "Get Token Metadata")(token_metadata)
+            views += [self.token_metadata]
+
+        metadata = {
+            **TZIP16_Metadata_Base,
+            "views"         : views
+        }
+
+        self.init_metadata("metadata", metadata)
+
+    def set_contract_metadata(self, metadata):
+        """
+           Set contract metadata
+        """
+        self.update_initial_storage(
+            metadata = sp.big_map(self.normalize_metadata(metadata))
+        )
+
+        if self.config.support_upgradable_metadata:
+            def update_metadata(self, key, value):
+                """
+                    An entry-point to allow the contract metadata to be updated.
+
+                    Can be removed with `FA12_config(support_upgradable_metadata = False, ...)`
+                """
+                sp.verify(self.is_administrator(sp.sender), FA12_Error.NotAdmin)
+                self.data.metadata[key] = value
+            self.update_metadata = sp.entry_point(update_metadata)
+
+class FA12(
+    FA12_mint_burn,
+    FA12_administrator,
+    FA12_pause,
+    FA12_token_metadata,
+    FA12_contract_metadata,
+    FA12_core
+):
+    def __init__(self, admin, config, token_metadata = None, contract_metadata = None):
+        FA12_core.__init__(self, config, paused = False, administrator = admin)
+
+        if token_metadata is None and contract_metadata is None:
+            raise Exception(
+            """\n
+                Contract must contain at least of the following:
+                    \t- TZIP-016 %metadata big-map,
+                    \t- Token-specific-metadata through the %token_metadata big-map
+
+                More info: https://gitlab.com/tzip/tzip/blob/master/proposals/tzip-7/tzip-7.md#token-metadata
+            """
+            )
+
+        self.usingTokenMetadata = False
+        if token_metadata is not None:
+            self.usingTokenMetadata = True
+            self.set_token_metadata(token_metadata)
+        if contract_metadata is not None:
+            self.set_contract_metadata(contract_metadata)
+
+        # This is only an helper, it produces metadata in the output panel
+        # that users can copy and upload to IPFS.
+        self.generate_tzip16_metadata()
+
+class Viewer(sp.Contract):
+    def __init__(self, t):
+        self.init(last = sp.none)
+        self.init_type(sp.TRecord(last = sp.TOption(t)))
+    @sp.entry_point
+    def target(self, params):
+        self.data.last = sp.some(params)
+
+# Used to test offchain views
+class TestOffchainView(sp.Contract):
+    def __init__(self, f):
+        self.f = f.f
+        self.init(result = sp.none)
+
+    @sp.entry_point
+    def compute(self, data, params):
+        b = sp.bind_block()
+        with b:
+            self.f(sp.record(data = data), params)
+        self.data.result = sp.some(b.value)
+
+if "templates" not in __name__:
+    @sp.add_test(name = "FA12")
+    def test():
+
+        scenario = sp.test_scenario()
+        scenario.h1("FA1.2 template - Fungible assets")
+
+        scenario.table_of_contents()
+
+        # sp.test_account generates ED25519 key-pairs deterministically:
+        admin = sp.test_account("Administrator")
+        alice = sp.test_account("Alice")
+        bob   = sp.test_account("Robert")
+
+        # Let's display the accounts:
+        scenario.h1("Accounts")
+        scenario.show([admin, alice, bob])
+
+        scenario.h1("Contract")
+        token_metadata = {
+            "decimals"    : "18",               # Mandatory by the spec
+            "name"        : "My Great Token",   # Recommended
+            "symbol"      : "MGT",              # Recommended
+            # Extra fields
+            "icon"        : 'https://smartpy.io/static/img/logo-only.svg'
+        }
+        contract_metadata = {
+            "" : "ipfs://QmaiAUj1FFNGYTu8rLBjc3eeN9cSKwaF8EGMBNDmhzPNFd",
+        }
+        c1 = FA12(
+            admin.address,
+            config              = FA12_config(support_upgradable_metadata = True),
+            token_metadata      = token_metadata,
+            contract_metadata   = contract_metadata
+        )
+        scenario += c1
+
+        scenario.h1("Offchain view - token_metadata")
+        # Test token_metadata view
+        offchainViewTester = TestOffchainView(c1.token_metadata)
+        scenario.register(offchainViewTester)
+        offchainViewTester.compute(data = c1.data, params = 0)
+        scenario.verify_equal(
+            offchainViewTester.data.result,
+            sp.some(
+                sp.record(
+                    token_id = 0,
+                    token_info = sp.map({
+                        "decimals"    : sp.utils.bytes_of_string("18"),
+                        "name"        : sp.utils.bytes_of_string("My Great Token"),
+                        "symbol"      : sp.utils.bytes_of_string("MGT"),
+                        "icon"        : sp.utils.bytes_of_string('https://smartpy.io/static/img/logo-only.svg')
+                    })
+                )
+            )
+        )
+
+        scenario.h1("Attempt to update metadata")
+        scenario.verify(
+            c1.data.metadata[""] == sp.utils.bytes_of_string("ipfs://QmaiAUj1FFNGYTu8rLBjc3eeN9cSKwaF8EGMBNDmhzPNFd")
+        )
+        c1.update_metadata(key = "", value = sp.bytes("0x00")).run(sender = admin)
+        scenario.verify(c1.data.metadata[""] == sp.bytes("0x00"))
+
+        scenario.h1("Entry points")
+        scenario.h2("Admin mints a few coins")
+        c1.mint(address = alice.address, value = 12).run(sender = admin)
+        c1.mint(address = alice.address, value = 3).run(sender = admin)
+        c1.mint(address = alice.address, value = 3).run(sender = admin)
+        scenario.h2("Alice transfers to Bob")
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 4).run(sender = alice)
+        scenario.verify(c1.data.balances[alice.address].balance == 14)
+        scenario.h2("Bob tries to transfer from Alice but he doesn't have her approval")
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 4).run(sender = bob, valid = False)
+        scenario.h2("Alice approves Bob and Bob transfers")
+        c1.approve(spender = bob.address, value = 5).run(sender = alice)
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 4).run(sender = bob)
+        scenario.h2("Bob tries to over-transfer from Alice")
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 4).run(sender = bob, valid = False)
+        scenario.h2("Admin burns Bob token")
+        c1.burn(address = bob.address, value = 1).run(sender = admin)
+        scenario.verify(c1.data.balances[alice.address].balance == 10)
+        scenario.h2("Alice tries to burn Bob token")
+        c1.burn(address = bob.address, value = 1).run(sender = alice, valid = False)
+        scenario.h2("Admin pauses the contract and Alice cannot transfer anymore")
+        c1.setPause(True).run(sender = admin)
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 4).run(sender = alice, valid = False)
+        scenario.verify(c1.data.balances[alice.address].balance == 10)
+        scenario.h2("Admin transfers while on pause")
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 1).run(sender = admin)
+        scenario.h2("Admin unpauses the contract and transferts are allowed")
+        c1.setPause(False).run(sender = admin)
+        scenario.verify(c1.data.balances[alice.address].balance == 9)
+        c1.transfer(from_ = alice.address, to_ = bob.address, value = 1).run(sender = alice)
+
+        scenario.verify(c1.data.totalSupply == 17)
+        scenario.verify(c1.data.balances[alice.address].balance == 8)
+        scenario.verify(c1.data.balances[bob.address].balance == 9)
+
+        scenario.h1("Views")
+        scenario.h2("Balance")
+        view_balance = Viewer(sp.TNat)
+        scenario += view_balance
+        c1.getBalance((alice.address, view_balance.typed.target))
+        scenario.verify_equal(view_balance.data.last, sp.some(8))
+
+        scenario.h2("Administrator")
+        view_administrator = Viewer(sp.TAddress)
+        scenario += view_administrator
+        c1.getAdministrator((sp.unit, view_administrator.typed.target))
+        scenario.verify_equal(view_administrator.data.last, sp.some(admin.address))
+
+        scenario.h2("Total Supply")
+        view_totalSupply = Viewer(sp.TNat)
+        scenario += view_totalSupply
+        c1.getTotalSupply((sp.unit, view_totalSupply.typed.target))
+        scenario.verify_equal(view_totalSupply.data.last, sp.some(17))
+
+        scenario.h2("Allowance")
+        view_allowance = Viewer(sp.TNat)
+        scenario += view_allowance
+        c1.getAllowance((sp.record(owner = alice.address, spender = bob.address), view_allowance.typed.target))
+        scenario.verify_equal(view_allowance.data.last, sp.some(1))
+
+    sp.add_compilation_target(
+        "FA1_2",
+        FA12(
+            admin   = sp.address("tz1M9CMEtsXm3QxA7FmMU2Qh7xzsuGXVbcDr"),
+            config  = FA12_config(
+                support_upgradable_metadata         = True,
+                use_token_metadata_offchain_view    = True
+            ),
+            token_metadata = {
+                "decimals"    : "18",             # Mandatory by the spec
+                "name"        : "My Great Token", # Recommended
+                "symbol"      : "MGT",            # Recommended
+                # Extra fields
+                "icon"        : 'https://smartpy.io/static/img/logo-only.svg'
+            },
+            contract_metadata = {
+                "" : "ipfs://QmaiAUj1FFNGYTu8rLBjc3eeN9cSKwaF8EGMBNDmhzPNFd",
+            }
+        )
+    )

--- a/smart_contracts/test-helpers/fa2.py
+++ b/smart_contracts/test-helpers/fa2.py
@@ -1,0 +1,1091 @@
+# Copied verbatim from SmartPy's templates on Nov 22, 2021
+
+##
+## ## Introduction
+##
+## See the FA2 standard definition:
+## <https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-12/>
+##
+## See more examples/documentation at
+## <https://gitlab.com/smondet/fa2-smartpy/> and
+## <https://assets.tqtezos.com/docs/token-contracts/fa2/1-fa2-smartpy/>.
+##
+import smartpy as sp
+##
+## ## Meta-Programming Configuration
+##
+## The `FA2_config` class holds the meta-programming configuration.
+##
+class FA2_config:
+    def __init__(self,
+                 debug_mode                         = False,
+                 single_asset                       = False,
+                 non_fungible                       = False,
+                 add_mutez_transfer                 = False,
+                 readable                           = True,
+                 force_layouts                      = True,
+                 support_operator                   = True,
+                 assume_consecutive_token_ids       = True,
+                 store_total_supply                 = True,
+                 lazy_entry_points                  = False,
+                 allow_self_transfer                = False,
+                 use_token_metadata_offchain_view   = False
+                 ):
+
+        if debug_mode:
+            self.my_map = sp.map
+        else:
+            self.my_map = sp.big_map
+        # The option `debug_mode` makes the code generation use
+        # regular maps instead of big-maps, hence it makes inspection
+        # of the state of the contract easier.
+
+        self.use_token_metadata_offchain_view = use_token_metadata_offchain_view
+        # Include offchain view for accessing the token metadata (requires TZIP-016 contract metadata)
+
+        self.single_asset = single_asset
+        # This makes the contract save some gas and storage by
+        # working only for the token-id `0`.
+
+        self.non_fungible = non_fungible
+        # Enforce the non-fungibility of the tokens, i.e. the fact
+        # that total supply has to be 1.
+
+        self.readable = readable
+        # The `readable` option is a legacy setting that we keep around
+        # only for benchmarking purposes.
+        #
+        # User-accounts are kept in a big-map:
+        # `(user-address * token-id) -> ownership-info`.
+        #
+        # For the Babylon protocol, one had to use `readable = False`
+        # in order to use `PACK` on the keys of the big-map.
+
+        self.force_layouts = force_layouts
+        # The specification requires all interface-fronting records
+        # and variants to be *right-combs;* we keep
+        # this parameter to be able to compare performance & code-size.
+
+        self.support_operator = support_operator
+        # The operator entry-points always have to be there, but there is
+        # definitely a use-case for having them completely empty (saving
+        # storage and gas when `support_operator` is `False).
+
+        self.assume_consecutive_token_ids = assume_consecutive_token_ids
+        # For a previous version of the TZIP specification, it was
+        # necessary to keep track of the set of all tokens in the contract.
+        #
+        # The set of tokens is for now still available; this parameter
+        # guides how to implement it:
+        # If `true` we don't need a real set of token ids, just to know how
+        # many there are.
+
+        self.store_total_supply = store_total_supply
+        # Whether to store the total-supply for each token (next to
+        # the token-metadata).
+
+        self.add_mutez_transfer = add_mutez_transfer
+        # Add an entry point for the administrator to transfer tez potentially
+        # in the contract's balance.
+
+        self.lazy_entry_points = lazy_entry_points
+        #
+        # Those are “compilation” options of SmartPy into Michelson.
+        #
+
+        self.allow_self_transfer = allow_self_transfer
+        # Authorize call of `transfer` entry_point from self
+        name = "FA2"
+        if debug_mode:
+            name += "-debug"
+        if single_asset:
+            name += "-single_asset"
+        if non_fungible:
+            name += "-nft"
+        if add_mutez_transfer:
+            name += "-mutez"
+        if not readable:
+            name += "-no_readable"
+        if not force_layouts:
+            name += "-no_layout"
+        if not support_operator:
+            name += "-no_ops"
+        if not assume_consecutive_token_ids:
+            name += "-no_toknat"
+        if not store_total_supply:
+            name += "-no_totsup"
+        if lazy_entry_points:
+            name += "-lep"
+        if allow_self_transfer:
+            name += "-self_transfer"
+        self.name = name
+
+## ## Auxiliary Classes and Values
+##
+## The definitions below implement SmartML-types and functions for various
+## important types.
+##
+token_id_type = sp.TNat
+
+class Error_message:
+    def __init__(self, config):
+        self.config = config
+        self.prefix = "FA2_"
+    def make(self, s): return (self.prefix + s)
+    def token_undefined(self):       return self.make("TOKEN_UNDEFINED")
+    def insufficient_balance(self):  return self.make("INSUFFICIENT_BALANCE")
+    def not_operator(self):          return self.make("NOT_OPERATOR")
+    def not_owner(self):             return self.make("NOT_OWNER")
+    def operators_unsupported(self): return self.make("OPERATORS_UNSUPPORTED")
+    def not_admin(self):             return self.make("NOT_ADMIN")
+    def not_admin_or_operator(self): return self.make("NOT_ADMIN_OR_OPERATOR")
+    def paused(self):                return self.make("PAUSED")
+
+## The current type for a batched transfer in the specification is as
+## follows:
+##
+## ```ocaml
+## type transfer = {
+##   from_ : address;
+##   txs: {
+##     to_ : address;
+##     token_id : token_id;
+##     amount : nat;
+##   } list
+## } list
+## ```
+##
+## This class provides helpers to create and force the type of such elements.
+## It uses the `FA2_config` to decide whether to set the right-comb layouts.
+class Batch_transfer:
+    def __init__(self, config):
+        self.config = config
+    def get_transfer_type(self):
+        tx_type = sp.TRecord(to_ = sp.TAddress,
+                             token_id = token_id_type,
+                             amount = sp.TNat)
+        if self.config.force_layouts:
+            tx_type = tx_type.layout(
+                ("to_", ("token_id", "amount"))
+            )
+        transfer_type = sp.TRecord(from_ = sp.TAddress,
+                                   txs = sp.TList(tx_type)).layout(
+                                       ("from_", "txs"))
+        return transfer_type
+    def get_type(self):
+        return sp.TList(self.get_transfer_type())
+    def item(self, from_, txs):
+        v = sp.record(from_ = from_, txs = txs)
+        return sp.set_type_expr(v, self.get_transfer_type())
+##
+## `Operator_param` defines type types for the `%update_operators` entry-point.
+class Operator_param:
+    def __init__(self, config):
+        self.config = config
+    def get_type(self):
+        t = sp.TRecord(
+            owner = sp.TAddress,
+            operator = sp.TAddress,
+            token_id = token_id_type)
+        if self.config.force_layouts:
+            t = t.layout(("owner", ("operator", "token_id")))
+        return t
+    def make(self, owner, operator, token_id):
+        r = sp.record(owner = owner,
+                      operator = operator,
+                      token_id = token_id)
+        return sp.set_type_expr(r, self.get_type())
+
+## The class `Ledger_key` defines the key type for the main ledger (big-)map:
+##
+## - In *“Babylon mode”* we also have to call `sp.pack`.
+## - In *“single-asset mode”* we can just use the user's address.
+class Ledger_key:
+    def __init__(self, config):
+        self.config = config
+    def make(self, user, token):
+        user = sp.set_type_expr(user, sp.TAddress)
+        token = sp.set_type_expr(token, token_id_type)
+        if self.config.single_asset:
+            result = user
+        else:
+            result = sp.pair(user, token)
+        if self.config.readable:
+            return result
+        else:
+            return sp.pack(result)
+
+## For now a value in the ledger is just the user's balance. Previous
+## versions of the specification required more information; potential
+## extensions may require other fields.
+class Ledger_value:
+    def get_type():
+        return sp.TRecord(balance = sp.TNat)
+    def make(balance):
+        return sp.record(balance = balance)
+
+## The link between operators and the addresses they operate is kept
+## in a *lazy set* of `(owner × operator × token-id)` values.
+##
+## A lazy set is a big-map whose keys are the elements of the set and
+## values are all `Unit`.
+class Operator_set:
+    def __init__(self, config):
+        self.config = config
+    def inner_type(self):
+        return sp.TRecord(owner = sp.TAddress,
+                          operator = sp.TAddress,
+                          token_id = token_id_type
+                          ).layout(("owner", ("operator", "token_id")))
+    def key_type(self):
+        if self.config.readable:
+            return self.inner_type()
+        else:
+            return sp.TBytes
+    def make(self):
+        return self.config.my_map(tkey = self.key_type(), tvalue = sp.TUnit)
+    def make_key(self, owner, operator, token_id):
+        metakey = sp.record(owner = owner,
+                            operator = operator,
+                            token_id = token_id)
+        metakey = sp.set_type_expr(metakey, self.inner_type())
+        if self.config.readable:
+            return metakey
+        else:
+            return sp.pack(metakey)
+    def add(self, set, owner, operator, token_id):
+        set[self.make_key(owner, operator, token_id)] = sp.unit
+    def remove(self, set, owner, operator, token_id):
+        del set[self.make_key(owner, operator, token_id)]
+    def is_member(self, set, owner, operator, token_id):
+        return set.contains(self.make_key(owner, operator, token_id))
+
+class Balance_of:
+    def request_type():
+        return sp.TRecord(
+            owner = sp.TAddress,
+            token_id = token_id_type).layout(("owner", "token_id"))
+    def response_type():
+        return sp.TList(
+            sp.TRecord(
+                request = Balance_of.request_type(),
+                balance = sp.TNat).layout(("request", "balance")))
+    def entry_point_type():
+        return sp.TRecord(
+            callback = sp.TContract(Balance_of.response_type()),
+            requests = sp.TList(Balance_of.request_type())
+        ).layout(("requests", "callback"))
+
+class Token_meta_data:
+    def __init__(self, config):
+        self.config = config
+
+    def get_type(self):
+        return sp.TRecord(token_id = sp.TNat, token_info = sp.TMap(sp.TString, sp.TBytes))
+
+    def set_type_and_layout(self, expr):
+        sp.set_type(expr, self.get_type())
+
+## The set of all tokens is represented by a `nat` if we assume that token-ids
+## are consecutive, or by an actual `(set nat)` if not.
+##
+## - Knowing the set of tokens is useful for throwing accurate error messages.
+## - Previous versions of the specification required this set for functional
+##   behavior (operators interface had to deal with “all tokens”).
+class Token_id_set:
+    def __init__(self, config):
+        self.config = config
+    def empty(self):
+        if self.config.assume_consecutive_token_ids:
+            # The "set" is its cardinal.
+            return sp.nat(0)
+        else:
+            return sp.set(t = token_id_type)
+    def add(self, totalTokens, tokenID):
+        if self.config.assume_consecutive_token_ids:
+            sp.verify(totalTokens == tokenID, message = "Token-IDs should be consecutive")
+            totalTokens.set(tokenID + 1)
+        else:
+            totalTokens.add(tokenID)
+    def contains(self, totalTokens, tokenID):
+        if self.config.assume_consecutive_token_ids:
+            return (tokenID < totalTokens)
+        else:
+            return totalTokens.contains(tokenID)
+    def cardinal(self, totalTokens):
+        if self.config.assume_consecutive_token_ids:
+            return totalTokens
+        else:
+            return sp.len(totalTokens)
+
+##
+## ## Implementation of the Contract
+##
+## `mutez_transfer` is an optional entry-point, hence we define it “outside” the
+## class:
+def mutez_transfer(contract, params):
+    sp.verify(sp.sender == contract.data.administrator)
+    sp.set_type(params.destination, sp.TAddress)
+    sp.set_type(params.amount, sp.TMutez)
+    sp.send(params.destination, params.amount)
+##
+## The `FA2` class builds a contract according to an `FA2_config` and an
+## administrator address.
+## It is inheriting from `FA2_core` which implements the strict
+## standard and a few other classes to add other common features.
+##
+## - We see the use of
+##   [`sp.entry_point`](https://smartpy.io/docs/introduction/entry_points)
+##   as a function instead of using annotations in order to allow
+##   optional entry points.
+## - The storage field `metadata_string` is a placeholder, the build
+##   system replaces the field annotation with a specific version-string, such
+##   as `"version_20200602_tzip_b916f32"`: the version of FA2-smartpy and
+##   the git commit in the TZIP [repository](https://gitlab.com/tzip/tzip) that
+##   the contract should obey.
+class FA2_core(sp.Contract):
+    def __init__(self, config, metadata, **extra_storage):
+        self.config = config
+        self.error_message = Error_message(self.config)
+        self.operator_set = Operator_set(self.config)
+        self.operator_param = Operator_param(self.config)
+        self.token_id_set = Token_id_set(self.config)
+        self.ledger_key = Ledger_key(self.config)
+        self.token_meta_data = Token_meta_data(self.config)
+        self.batch_transfer    = Batch_transfer(self.config)
+        if  self.config.add_mutez_transfer:
+            self.transfer_mutez = sp.entry_point(mutez_transfer)
+        if config.lazy_entry_points:
+            self.add_flag("lazy-entry-points")
+        self.add_flag("initial-cast")
+        self.exception_optimization_level = "default-line"
+        self.init(
+            ledger = self.config.my_map(tvalue = Ledger_value.get_type()),
+            token_metadata = self.config.my_map(tkey = sp.TNat, tvalue = self.token_meta_data.get_type()),
+            operators = self.operator_set.make(),
+            all_tokens = self.token_id_set.empty(),
+            metadata = metadata,
+            **extra_storage
+        )
+
+        if self.config.store_total_supply:
+            self.update_initial_storage(
+                total_supply = self.config.my_map(tkey = sp.TNat, tvalue = sp.TNat),
+            )
+
+    @sp.entry_point
+    def transfer(self, params):
+        sp.verify( ~self.is_paused(), message = self.error_message.paused() )
+        sp.set_type(params, self.batch_transfer.get_type())
+        sp.for transfer in params:
+           current_from = transfer.from_
+           sp.for tx in transfer.txs:
+                if self.config.single_asset:
+                    sp.verify(tx.token_id == 0, message = "single-asset: token-id <> 0")
+
+                sender_verify = ((self.is_administrator(sp.sender)) |
+                                (current_from == sp.sender))
+                message = self.error_message.not_owner()
+                if self.config.support_operator:
+                    message = self.error_message.not_operator()
+                    sender_verify |= (self.operator_set.is_member(self.data.operators,
+                                                                  current_from,
+                                                                  sp.sender,
+                                                                  tx.token_id))
+                if self.config.allow_self_transfer:
+                    sender_verify |= (sp.sender == sp.self_address)
+                sp.verify(sender_verify, message = message)
+                sp.verify(
+                    self.data.token_metadata.contains(tx.token_id),
+                    message = self.error_message.token_undefined()
+                )
+                # If amount is 0 we do nothing now:
+                sp.if (tx.amount > 0):
+                    from_user = self.ledger_key.make(current_from, tx.token_id)
+                    sp.verify(
+                        (self.data.ledger[from_user].balance >= tx.amount),
+                        message = self.error_message.insufficient_balance())
+                    to_user = self.ledger_key.make(tx.to_, tx.token_id)
+                    self.data.ledger[from_user].balance = sp.as_nat(
+                        self.data.ledger[from_user].balance - tx.amount)
+                    sp.if self.data.ledger.contains(to_user):
+                        self.data.ledger[to_user].balance += tx.amount
+                    sp.else:
+                         self.data.ledger[to_user] = Ledger_value.make(tx.amount)
+                sp.else:
+                    pass
+
+    @sp.entry_point
+    def balance_of(self, params):
+        # paused may mean that balances are meaningless:
+        sp.verify( ~self.is_paused(), message = self.error_message.paused())
+        sp.set_type(params, Balance_of.entry_point_type())
+        def f_process_request(req):
+            user = self.ledger_key.make(req.owner, req.token_id)
+            sp.verify(self.data.token_metadata.contains(req.token_id), message = self.error_message.token_undefined())
+            sp.if self.data.ledger.contains(user):
+                balance = self.data.ledger[user].balance
+                sp.result(
+                    sp.record(
+                        request = sp.record(
+                            owner = sp.set_type_expr(req.owner, sp.TAddress),
+                            token_id = sp.set_type_expr(req.token_id, sp.TNat)),
+                        balance = balance))
+            sp.else:
+                sp.result(
+                    sp.record(
+                        request = sp.record(
+                            owner = sp.set_type_expr(req.owner, sp.TAddress),
+                            token_id = sp.set_type_expr(req.token_id, sp.TNat)),
+                        balance = 0))
+        res = sp.local("responses", params.requests.map(f_process_request))
+        destination = sp.set_type_expr(params.callback, sp.TContract(Balance_of.response_type()))
+        sp.transfer(res.value, sp.mutez(0), destination)
+
+    @sp.offchain_view(pure = True)
+    def get_balance(self, req):
+        """This is the `get_balance` view defined in TZIP-12."""
+        sp.set_type(
+            req, sp.TRecord(
+                owner = sp.TAddress,
+                token_id = sp.TNat
+            ).layout(("owner", "token_id")))
+        user = self.ledger_key.make(req.owner, req.token_id)
+        sp.verify(self.data.token_metadata.contains(req.token_id), message = self.error_message.token_undefined())
+        sp.result(self.data.ledger[user].balance)
+
+
+    @sp.entry_point
+    def update_operators(self, params):
+        sp.set_type(params, sp.TList(
+            sp.TVariant(
+                add_operator = self.operator_param.get_type(),
+                remove_operator = self.operator_param.get_type()
+            )
+        ))
+        if self.config.support_operator:
+            sp.for update in params:
+                with update.match_cases() as arg:
+                    with arg.match("add_operator") as upd:
+                        sp.verify(
+                            (upd.owner == sp.sender) | self.is_administrator(sp.sender),
+                            message = self.error_message.not_admin_or_operator()
+                        )
+                        self.operator_set.add(self.data.operators,
+                                              upd.owner,
+                                              upd.operator,
+                                              upd.token_id)
+                    with arg.match("remove_operator") as upd:
+                        sp.verify(
+                            (upd.owner == sp.sender) | self.is_administrator(sp.sender),
+                            message = self.error_message.not_admin_or_operator()
+                        )
+                        self.operator_set.remove(self.data.operators,
+                                                 upd.owner,
+                                                 upd.operator,
+                                                 upd.token_id)
+        else:
+            sp.failwith(self.error_message.operators_unsupported())
+
+    # this is not part of the standard but can be supported through inheritance.
+    def is_paused(self):
+        return sp.bool(False)
+
+    # this is not part of the standard but can be supported through inheritance.
+    def is_administrator(self, sender):
+        return sp.bool(False)
+
+class FA2_administrator(FA2_core):
+    def is_administrator(self, sender):
+        return sender == self.data.administrator
+
+    @sp.entry_point
+    def set_administrator(self, params):
+        sp.verify(self.is_administrator(sp.sender), message = self.error_message.not_admin())
+        self.data.administrator = params
+
+class FA2_pause(FA2_core):
+    def is_paused(self):
+        return self.data.paused
+
+    @sp.entry_point
+    def set_pause(self, params):
+        sp.verify(self.is_administrator(sp.sender), message = self.error_message.not_admin())
+        self.data.paused = params
+
+class FA2_change_metadata(FA2_core):
+    @sp.entry_point
+    def set_metadata(self, k, v):
+        sp.verify(self.is_administrator(sp.sender), message = self.error_message.not_admin())
+        self.data.metadata[k] = v
+
+class FA2_mint(FA2_core):
+    @sp.entry_point
+    def mint(self, params):
+        sp.verify(self.is_administrator(sp.sender), message = self.error_message.not_admin())
+        # We don't check for pauseness because we're the admin.
+        if self.config.single_asset:
+            sp.verify(params.token_id == 0, message = "single-asset: token-id <> 0")
+        if self.config.non_fungible:
+            sp.verify(params.amount == 1, message = "NFT-asset: amount <> 1")
+            sp.verify(
+                ~ self.token_id_set.contains(self.data.all_tokens, params.token_id),
+                message = "NFT-asset: cannot mint twice same token"
+            )
+        user = self.ledger_key.make(params.address, params.token_id)
+        sp.if self.data.ledger.contains(user):
+            self.data.ledger[user].balance += params.amount
+        sp.else:
+            self.data.ledger[user] = Ledger_value.make(params.amount)
+        sp.if ~ self.token_id_set.contains(self.data.all_tokens, params.token_id):
+            self.token_id_set.add(self.data.all_tokens, params.token_id)
+            self.data.token_metadata[params.token_id] = sp.record(
+                token_id    = params.token_id,
+                token_info  = params.metadata
+            )
+        if self.config.store_total_supply:
+            self.data.total_supply[params.token_id] = params.amount + self.data.total_supply.get(params.token_id, default_value = 0)
+
+class FA2_token_metadata(FA2_core):
+    def set_token_metadata_view(self):
+        def token_metadata(self, tok):
+            """
+            Return the token-metadata URI for the given token.
+
+            For a reference implementation, dynamic-views seem to be the
+            most flexible choice.
+            """
+            sp.set_type(tok, sp.TNat)
+            sp.result(self.data.token_metadata[tok])
+
+        self.token_metadata = sp.offchain_view(pure = True, doc = "Get Token Metadata")(token_metadata)
+
+    def make_metadata(symbol, name, decimals):
+        "Helper function to build metadata JSON bytes values."
+        return (sp.map(l = {
+            # Remember that michelson wants map already in ordered
+            "decimals" : sp.utils.bytes_of_string("%d" % decimals),
+            "name" : sp.utils.bytes_of_string(name),
+            "symbol" : sp.utils.bytes_of_string(symbol)
+        }))
+
+
+class FA2(FA2_change_metadata, FA2_token_metadata, FA2_mint, FA2_administrator, FA2_pause, FA2_core):
+
+    @sp.offchain_view(pure = True)
+    def count_tokens(self):
+        """Get how many tokens are in this FA2 contract.
+        """
+        sp.result(self.token_id_set.cardinal(self.data.all_tokens))
+
+    @sp.offchain_view(pure = True)
+    def does_token_exist(self, tok):
+        "Ask whether a token ID is exists."
+        sp.set_type(tok, sp.TNat)
+        sp.result(self.data.token_metadata.contains(tok))
+
+    @sp.offchain_view(pure = True)
+    def all_tokens(self):
+        if self.config.assume_consecutive_token_ids:
+            sp.result(sp.range(0, self.data.all_tokens))
+        else:
+            sp.result(self.data.all_tokens.elements())
+
+    @sp.offchain_view(pure = True)
+    def total_supply(self, tok):
+        if self.config.store_total_supply:
+            sp.result(self.data.total_supply[tok])
+        else:
+            sp.set_type(tok, sp.TNat)
+            sp.result("total-supply not supported")
+
+    @sp.offchain_view(pure = True)
+    def is_operator(self, query):
+        sp.set_type(query,
+                    sp.TRecord(token_id = sp.TNat,
+                               owner = sp.TAddress,
+                               operator = sp.TAddress).layout(
+                                   ("owner", ("operator", "token_id"))))
+        sp.result(
+            self.operator_set.is_member(self.data.operators,
+                                        query.owner,
+                                        query.operator,
+                                        query.token_id)
+        )
+
+    def __init__(self, config, metadata, admin):
+        # Let's show off some meta-programming:
+        if config.assume_consecutive_token_ids:
+            self.all_tokens.doc = """
+            This view is specified (but optional) in the standard.
+
+            This contract is built with assume_consecutive_token_ids =
+            True, so we return a list constructed from the number of tokens.
+            """
+        else:
+            self.all_tokens.doc = """
+            This view is specified (but optional) in the standard.
+
+            This contract is built with assume_consecutive_token_ids =
+            False, so we convert the set of tokens from the storage to a list
+            to fit the expected type of TZIP-16.
+            """
+        list_of_views = [
+            self.get_balance
+            , self.does_token_exist
+            , self.count_tokens
+            , self.all_tokens
+            , self.is_operator
+        ]
+
+        if config.store_total_supply:
+            list_of_views = list_of_views + [self.total_supply]
+        if config.use_token_metadata_offchain_view:
+            self.set_token_metadata_view()
+            list_of_views = list_of_views + [self.token_metadata]
+
+        metadata_base = {
+            "version": config.name # will be changed if using fatoo.
+            , "description" : (
+                "This is a didactic reference implementation of FA2,"
+                + " a.k.a. TZIP-012, using SmartPy.\n\n"
+                + "This particular contract uses the configuration named: "
+                + config.name + "."
+            )
+            , "interfaces": ["TZIP-012", "TZIP-016"]
+            , "authors": [
+                "Seb Mondet <https://seb.mondet.org>"
+            ]
+            , "homepage": "https://gitlab.com/smondet/fa2-smartpy"
+            , "views": list_of_views
+            , "source": {
+                "tools": ["SmartPy"]
+                , "location": "https://gitlab.com/smondet/fa2-smartpy.git"
+            }
+            , "permissions": {
+                "operator":
+                "owner-or-operator-transfer" if config.support_operator else "owner-transfer"
+                , "receiver": "owner-no-hook"
+                , "sender": "owner-no-hook"
+            }
+            , "fa2-smartpy": {
+                "configuration" :
+                dict([(k, getattr(config, k)) for k in dir(config) if "__" not in k and k != 'my_map'])
+            }
+        }
+        self.init_metadata("metadata_base", metadata_base)
+        FA2_core.__init__(self, config, metadata, paused = False, administrator = admin)
+
+## ## Tests
+##
+## ### Auxiliary Consumer Contract
+##
+## This contract is used by the tests to be on the receiver side of
+## callback-based entry-points.
+## It stores facts about the results in order to use `scenario.verify(...)`
+## (cf.
+##  [documentation](https://smartpy.io/docs/scenarios/testing)).
+class View_consumer(sp.Contract):
+    def __init__(self, contract):
+        self.contract = contract
+        self.init(last_sum = 0,
+                  operator_support =  not contract.config.support_operator)
+
+    @sp.entry_point
+    def reinit(self):
+        self.data.last_sum = 0
+        # It's also nice to make this contract have more than one entry point.
+
+    @sp.entry_point
+    def receive_balances(self, params):
+        sp.set_type(params, Balance_of.response_type())
+        self.data.last_sum = 0
+        sp.for resp in params:
+            self.data.last_sum += resp.balance
+
+## ### Generation of Test Scenarios
+##
+## Tests are also parametrized by the `FA2_config` object.
+## The best way to visualize them is to use the online IDE
+## (<https://www.smartpy.io/ide/>).
+def add_test(config, is_default = True):
+    @sp.add_test(name = config.name, is_default = is_default)
+    def test():
+        scenario = sp.test_scenario()
+        scenario.h1("FA2 Contract Name: " + config.name)
+        scenario.table_of_contents()
+        # sp.test_account generates ED25519 key-pairs deterministically:
+        admin = sp.test_account("Administrator")
+        alice = sp.test_account("Alice")
+        bob   = sp.test_account("Robert")
+        # Let's display the accounts:
+        scenario.h2("Accounts")
+        scenario.show([admin, alice, bob])
+        c1 = FA2(config = config,
+                 metadata = sp.utils.metadata_of_url("https://example.com"),
+                 admin = admin.address)
+        scenario += c1
+        if config.non_fungible:
+            # TODO
+            return
+        scenario.h2("Initial Minting")
+        scenario.p("The administrator mints 100 token-0's to Alice.")
+        tok0_md = FA2.make_metadata(
+            name = "The Token Zero",
+            decimals = 2,
+            symbol= "TK0" )
+        c1.mint(address = alice.address,
+                            amount = 50,
+                            metadata = tok0_md,
+                            token_id = 0).run(sender = admin)
+        # Mint a second time
+        c1.mint(address = alice.address,
+                            amount = 50,
+                            metadata = tok0_md,
+                            token_id = 0).run(sender = admin)
+        scenario.h2("Transfers Alice -> Bob")
+        c1.transfer(
+            [
+                c1.batch_transfer.item(from_ = alice.address,
+                                    txs = [
+                                        sp.record(to_ = bob.address,
+                                                  amount = 10,
+                                                  token_id = 0)
+                                    ])
+            ]).run(sender = alice)
+        scenario.verify(
+            c1.data.ledger[c1.ledger_key.make(alice.address, 0)].balance == 90)
+        scenario.verify(
+            c1.data.ledger[c1.ledger_key.make(bob.address, 0)].balance == 10)
+        c1.transfer(
+            [
+                c1.batch_transfer.item(from_ = alice.address,
+                                    txs = [
+                                        sp.record(to_ = bob.address,
+                                                  amount = 10,
+                                                  token_id = 0),
+                                        sp.record(to_ = bob.address,
+                                                  amount = 11,
+                                                  token_id = 0)
+                                    ])
+            ]).run(sender = alice)
+        scenario.verify(
+            c1.data.ledger[c1.ledger_key.make(alice.address, 0)].balance == 90 - 10 - 11
+        )
+        scenario.verify(
+            c1.data.ledger[c1.ledger_key.make(bob.address, 0)].balance
+            == 10 + 10 + 11)
+        if config.single_asset:
+            return
+        scenario.h2("More Token Types")
+        tok1_md = FA2.make_metadata(
+            name = "The Second Token",
+            decimals = 0,
+            symbol= "TK1" )
+        c1.mint(address = bob.address,
+                            amount = 100,
+                            metadata = tok1_md,
+                            token_id = 1).run(sender = admin)
+        tok2_md = FA2.make_metadata(
+            name = "The Token Number Three",
+            decimals = 0,
+            symbol= "TK2" )
+        c1.mint(address = bob.address,
+                            amount = 200,
+                            metadata = tok2_md,
+                            token_id = 2).run(sender = admin)
+        scenario.h3("Multi-token Transfer Bob -> Alice")
+        c1.transfer(
+            [
+                c1.batch_transfer.item(from_ = bob.address,
+                                    txs = [
+                                        sp.record(to_ = alice.address,
+                                                  amount = 10,
+                                                  token_id = 0),
+                                        sp.record(to_ = alice.address,
+                                                  amount = 10,
+                                                  token_id = 1)]),
+                # We voluntarily test a different sub-batch:
+                c1.batch_transfer.item(from_ = bob.address,
+                                    txs = [
+                                        sp.record(to_ = alice.address,
+                                                  amount = 10,
+                                                  token_id = 2)])
+            ]).run(sender = bob)
+        scenario.h2("Other Basic Permission Tests")
+        scenario.h3("Bob cannot transfer Alice's tokens.")
+        c1.transfer(
+            [
+                c1.batch_transfer.item(from_ = alice.address,
+                                    txs = [
+                                        sp.record(to_ = bob.address,
+                                                  amount = 10,
+                                                  token_id = 0),
+                                        sp.record(to_ = bob.address,
+                                                  amount = 1,
+                                                  token_id = 0)])
+            ]).run(sender = bob, valid = False)
+        scenario.h3("Admin can transfer anything.")
+        c1.transfer(
+            [
+                c1.batch_transfer.item(from_ = alice.address,
+                                    txs = [
+                                        sp.record(to_ = bob.address,
+                                                  amount = 10,
+                                                  token_id = 0),
+                                        sp.record(to_ = bob.address,
+                                                  amount = 10,
+                                                  token_id = 1)]),
+                c1.batch_transfer.item(from_ = bob.address,
+                                    txs = [
+                                        sp.record(to_ = alice.address,
+                                                  amount = 11,
+                                                  token_id = 0)])
+            ]).run(sender = admin)
+        scenario.h3("Even Admin cannot transfer too much.")
+        c1.transfer(
+            [
+                c1.batch_transfer.item(from_ = alice.address,
+                                    txs = [
+                                        sp.record(to_ = bob.address,
+                                                  amount = 1000,
+                                                  token_id = 0)])
+            ]).run(sender = admin, valid = False)
+        scenario.h3("Consumer Contract for Callback Calls.")
+        consumer = View_consumer(c1)
+        scenario += consumer
+        scenario.p("Consumer virtual address: "
+                   + consumer.address.export())
+        scenario.h2("Balance-of.")
+        def arguments_for_balance_of(receiver, reqs):
+            return (sp.record(
+                callback = sp.contract(
+                    Balance_of.response_type(),
+                    receiver.address,
+                    entry_point = "receive_balances").open_some(),
+                requests = reqs))
+        c1.balance_of(arguments_for_balance_of(consumer, [
+            sp.record(owner = alice.address, token_id = 0),
+            sp.record(owner = alice.address, token_id = 1),
+            sp.record(owner = alice.address, token_id = 2)
+        ]))
+        scenario.verify(consumer.data.last_sum == 90)
+        scenario.h2("Operators")
+        if not c1.config.support_operator:
+            scenario.h3("This version was compiled with no operator support")
+            scenario.p("Calls should fail even for the administrator:")
+            c1.update_operators([]).run(sender = admin, valid = False)
+        else:
+            scenario.p("This version was compiled with operator support.")
+            scenario.p("Calling 0 updates should work:")
+            c1.update_operators([]).run()
+            scenario.h3("Operator Accounts")
+            op0 = sp.test_account("Operator0")
+            op1 = sp.test_account("Operator1")
+            op2 = sp.test_account("Operator2")
+            scenario.show([op0, op1, op2])
+            scenario.p("Admin can change Alice's operator.")
+            c1.update_operators([
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = alice.address,
+                    operator = op1.address,
+                    token_id = 0)),
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = alice.address,
+                    operator = op1.address,
+                    token_id = 2))
+            ]).run(sender = admin)
+            scenario.p("Operator1 can now transfer Alice's tokens 0 and 2")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = alice.address,
+                                        txs = [
+                                            sp.record(to_ = bob.address,
+                                                      amount = 2,
+                                                      token_id = 0),
+                                            sp.record(to_ = op1.address,
+                                                      amount = 2,
+                                                      token_id = 2)])
+                ]).run(sender = op1)
+            scenario.p("Operator1 cannot transfer Bob's tokens")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = bob.address,
+                                        txs = [
+                                            sp.record(to_ = op1.address,
+                                                      amount = 2,
+                                                      token_id = 1)])
+                ]).run(sender = op1, valid = False)
+            scenario.p("Operator2 cannot transfer Alice's tokens")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = alice.address,
+                                        txs = [
+                                            sp.record(to_ = bob.address,
+                                                      amount = 2,
+                                                      token_id = 1)])
+                ]).run(sender = op2, valid = False)
+            scenario.p("Alice can remove their operator")
+            c1.update_operators([
+                sp.variant("remove_operator", c1.operator_param.make(
+                    owner = alice.address,
+                    operator = op1.address,
+                    token_id = 0)),
+                sp.variant("remove_operator", c1.operator_param.make(
+                    owner = alice.address,
+                    operator = op1.address,
+                    token_id = 0))
+            ]).run(sender = alice)
+            scenario.p("Operator1 cannot transfer Alice's tokens any more")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = alice.address,
+                                        txs = [
+                                            sp.record(to_ = op1.address,
+                                                      amount = 2,
+                                                      token_id = 1)])
+                ]).run(sender = op1, valid = False)
+            scenario.p("Bob can add Operator0.")
+            c1.update_operators([
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = bob.address,
+                    operator = op0.address,
+                    token_id = 0)),
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = bob.address,
+                    operator = op0.address,
+                    token_id = 1))
+            ]).run(sender = bob)
+            scenario.p("Operator0 can transfer Bob's tokens '0' and '1'")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = bob.address,
+                                        txs = [
+                                            sp.record(to_ = alice.address,
+                                                      amount = 1,
+                                                      token_id = 0)]),
+                    c1.batch_transfer.item(from_ = bob.address,
+                                        txs = [
+                                            sp.record(to_ = alice.address,
+                                                      amount = 1,
+                                                      token_id = 1)])
+                ]).run(sender = op0)
+            scenario.p("Bob cannot add Operator0 for Alice's tokens.")
+            c1.update_operators([
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = alice.address,
+                    operator = op0.address,
+                    token_id = 0
+                ))
+            ]).run(sender = bob, valid = False)
+            scenario.p("Alice can also add Operator0 for their tokens 0.")
+            c1.update_operators([
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = alice.address,
+                    operator = op0.address,
+                    token_id = 0
+                ))
+            ]).run(sender = alice, valid = True)
+            scenario.p("Operator0 can now transfer Bob's and Alice's 0-tokens.")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = bob.address,
+                                        txs = [
+                                            sp.record(to_ = alice.address,
+                                                      amount = 1,
+                                                      token_id = 0)]),
+                    c1.batch_transfer.item(from_ = alice.address,
+                                        txs = [
+                                            sp.record(to_ = bob.address,
+                                                      amount = 1,
+                                                      token_id = 0)])
+                ]).run(sender = op0)
+            scenario.p("Bob adds Operator2 as second operator for 0-tokens.")
+            c1.update_operators([
+                sp.variant("add_operator", c1.operator_param.make(
+                    owner = bob.address,
+                    operator = op2.address,
+                    token_id = 0
+                ))
+            ]).run(sender = bob, valid = True)
+            scenario.p("Operator0 and Operator2 can transfer Bob's 0-tokens.")
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = bob.address,
+                                        txs = [
+                                            sp.record(to_ = alice.address,
+                                                      amount = 1,
+                                                      token_id = 0)])
+                ]).run(sender = op0)
+            c1.transfer(
+                [
+                    c1.batch_transfer.item(from_ = bob.address,
+                                        txs = [
+                                            sp.record(to_ = alice.address,
+                                                      amount = 1,
+                                                      token_id = 0)])
+                ]).run(sender = op2)
+            scenario.table_of_contents()
+
+##
+## ## Global Environment Parameters
+##
+## The build system communicates with the python script through
+## environment variables.
+## The function `environment_config` creates an `FA2_config` given the
+## presence and values of a few environment variables.
+def global_parameter(env_var, default):
+    try:
+        if os.environ[env_var] == "true" :
+            return True
+        if os.environ[env_var] == "false" :
+            return False
+        return default
+    except:
+        return default
+
+def environment_config():
+    return FA2_config(
+        debug_mode = global_parameter("debug_mode", False),
+        single_asset = global_parameter("single_asset", False),
+        non_fungible = global_parameter("non_fungible", False),
+        add_mutez_transfer = global_parameter("add_mutez_transfer", False),
+        readable = global_parameter("readable", True),
+        force_layouts = global_parameter("force_layouts", True),
+        support_operator = global_parameter("support_operator", True),
+        assume_consecutive_token_ids =
+            global_parameter("assume_consecutive_token_ids", True),
+        store_total_supply = global_parameter("store_total_supply", False),
+        lazy_entry_points = global_parameter("lazy_entry_points", False),
+        allow_self_transfer = global_parameter("allow_self_transfer", False),
+        use_token_metadata_offchain_view = global_parameter("use_token_metadata_offchain_view", True),
+    )
+
+## ## Standard “main”
+##
+## This specific main uses the relative new feature of non-default tests
+## for the browser version.
+if "templates" not in __name__:
+    add_test(environment_config())
+    if not global_parameter("only_environment_test", False):
+        add_test(FA2_config(debug_mode = True), is_default = not sp.in_browser)
+        add_test(FA2_config(single_asset = True), is_default = not sp.in_browser)
+        add_test(FA2_config(non_fungible = True, add_mutez_transfer = True),
+                 is_default = not sp.in_browser)
+        add_test(FA2_config(readable = False), is_default = not sp.in_browser)
+        add_test(FA2_config(force_layouts = False),
+                 is_default = not sp.in_browser)
+        add_test(FA2_config(debug_mode = True, support_operator = False),
+                 is_default = not sp.in_browser)
+        add_test(FA2_config(assume_consecutive_token_ids = False)
+                 , is_default = not sp.in_browser)
+        add_test(FA2_config(store_total_supply = True)
+                 , is_default = not sp.in_browser)
+        add_test(FA2_config(add_mutez_transfer = True)
+                 , is_default = not sp.in_browser)
+        add_test(FA2_config(lazy_entry_points = True)
+                 , is_default = not sp.in_browser)
+
+    sp.add_compilation_target("FA2_comp", FA2(config = environment_config(),
+                              metadata = sp.utils.metadata_of_url("https://example.com"),
+                              admin = sp.address("tz1M9CMEtsXm3QxA7FmMU2Qh7xzsuGXVbcDr")))


### PR DESCRIPTION
Add some methods for managing the balance of the developer and stability fund. This makes it easier to zero these funds in the future. 

- `sendAll`: Sends all the XTZ in the fund elsewhere
- `sendAllTokens`/`sendAllTokens_callback`: Sends all the kUSD in the fund elsewhere
- `rescueFA12`/`rescueFA2`: Move arbitrary FA1.2 and FA2 tokens from the fund

Sending all XTZ or kUSD in the fund is motivated by the fact that the KSR migration will need to occur in two steps. Rescuing arbitrary FA1.2 and FA2 tokens is an additional enhancement, in case the fund ever receives airdrops or accidentally receives tokens. 