### PR TITLE
[FIX/Feature] Usage of Ubinetic On Demand oracle for retrieve prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Directory Structure
 
 - `deploy/`: NPM package to deploy the system.
-- `smart_contracts/`: SmartPy Smart Contracts and compiled michelson code
+- `smart_contracts/`: SmartPy/JsLIGO Smart Contracts and compiled michelson code
 - `migrations/`: Migrtion tools for moving between contract versions

--- a/deploy/src/deploy-contracts.ts
+++ b/deploy/src/deploy-contracts.ts
@@ -31,6 +31,11 @@ const HARBINGER_NORMALIZER = IS_MAINNET
   ? 'KT1AdbYiPYb5hDuEuVrfxmFehtnBCXv4Np7r'
   : 'KT1SUP27JhX24Kvr11oUdWswk7FnCW78ZyUn'
 
+// UBINETIC On-Demand Proxy Contract to call on.
+const UBINETIC_ON_DEMAND_PROXY = IS_MAINNET
+  ? 'KT1B74ywpG3nX2F3ZgpYi4MnsyuoYyQtQTAn'
+  : null // FIXME: No contract in ghostnet
+
 // Key which will deploy the contracts.
 const DEPLOYER_PRIVATE_KEY =
   'edsk3aeocSRnxdWVFm3ShaALUeCTy4PgL6JdeGvzbLjX5jn8D9ZXw5'
@@ -123,6 +128,9 @@ async function main() {
   )
   const oracleSource = loadContract(
     `${__dirname}/../../smart_contracts/oracle.tz`,
+  )
+  const oracleOnDemandSource = loadContract(
+    `${__dirname}/../../smart_contracts/oracle-on-demand.tz`,
   )
   console.log('Contracts loaded.')
   console.log('')
@@ -245,11 +253,28 @@ async function main() {
   console.log('Deployed.')
   console.log('')
 
+  // FIXME: Outdated oracle
+  // console.log('>>> [8/9] Deploying Oracle Contract...')
+  // // Constants:
+  // // clientCallback: None
+  // // state: 0 (IDLE)
+  // const oracleStorage = `(Pair(Pair None "${keystore.publicKeyHash}")(Pair "${HARBINGER_NORMALIZER}"(Pair ${MAX_DATA_DELAY_SECS} 0)))`
+  // counter++
+  // const oracleDeployResult = await deployContract(
+  //   oracleSource,
+  //   oracleStorage,
+  //   keystore,
+  //   counter,
+  //   NODE_ADDRESS,
+  // )
+  // console.log('Deployed.')
+  // console.log('')
+
   console.log('>>> [8/9] Deploying Oracle Contract...')
-  // Constants:
-  // clientCallback: None
-  // state: 0 (IDLE)
-  const oracleStorage = `(Pair(Pair None "${keystore.publicKeyHash}")(Pair "${HARBINGER_NORMALIZER}"(Pair ${MAX_DATA_DELAY_SECS} 0)))`
+  // TODO: Check if this format is correct
+  // Alt format will be: 
+  // `(Pair "${UBINETIC_ON_DEMAND_PROXY}" ${MAX_DATA_DELAY_SECS} "${keystore.publicKeyHash}")`
+  const oracleStorage = `(Pair "${UBINETIC_ON_DEMAND_PROXY}" (Pair ${MAX_DATA_DELAY_SECS} "${keystore.publicKeyHash}"))`
   counter++
   const oracleDeployResult = await deployContract(
     oracleSource,

--- a/smart_contracts/Makefile
+++ b/smart_contracts/Makefile
@@ -1,6 +1,12 @@
 SMART_PY_CLI := ~/smartpy-cli/SmartPy.sh
 OUT_DIR := ./.smartpy_out
 
+LIGO_CLI := ligo
+
+# Ensure we have a Ligo binary.
+check-ligo:
+	@type $(LIGO_CLI) >/dev/null 2>&1
+
 ###### AGGREGATE TARGETS ###### 
 
 all:
@@ -16,6 +22,7 @@ compile:
 	make compile-savings-pool
 	make compile-stability-fund
 	make compile-token
+	make compile-oracle-on-demand
 
 # TODO(keefertaylor): Write rules for all contracts, and add them here.
 test:
@@ -27,6 +34,7 @@ test:
 	make test-stability-fund
 	make test-token	
 	make test-e2e
+	make test-oracle-on-demand
 
 ###### TESTS ###### 
 
@@ -113,3 +121,9 @@ compile-token:
 	$(SMART_PY_CLI) compile token.py $(OUT_DIR)
 	cp $(OUT_DIR)/token/step_000_cont_0_contract.tz token.tz
 	rm -rf $(OUT_DIR)	
+
+compile-oracle-on-demand: check-ligo
+	$(LIGO_CLI) compile contract oracle-on-demand.jsligo -m KolibriOracleAdapter -o oracle-on-demand.tz
+
+test-oracle-on-demand: check-ligo
+	$(LIGO_CLI) run test oracle-on-demand.jsligo

--- a/smart_contracts/README.md
+++ b/smart_contracts/README.md
@@ -2,6 +2,9 @@
 
 Smart contracts are written with [SmartPy](https://SmartPy.io). To work with them, you'll need to install the SmartPy CLI.
 
+### Oracle On demand note
+[oracle-on-demand](./oracle-on-demand.jsligo) written with LIGO (JsLIGO) using 1.7.0 version. To compile it you need to to install the LIGO cli. [See  instructions here](https://ligolang.org/docs/intro/installation)
+
 ## Building
 
 ```shell

--- a/smart_contracts/compile.sh
+++ b/smart_contracts/compile.sh
@@ -9,15 +9,25 @@ echo "----------------------------------------"
 # Expected location of SmartPy CLI.
 SMART_PY_CLI=~/smartpy-cli/SmartPy.sh
 
+# Expected location of ligo.
+LIGO_CLI=ligo
+
 # Output directory
 OUT_DIR=./.smartpy_out
 
 # Parallel sorted arrays.
-CONTRACTS_ARRAY=(oven-factory dev-fund token stability-fund minter oven-proxy oracle oven oven-registry sandbox-oracle savings-pool)
+CONTRACTS_ARRAY=(oven-factory dev-fund token stability-fund minter oven-proxy oracle oracle-on-demand oven oven-registry sandbox-oracle savings-pool)
 
-# Ensure we have a SmartPy binary.
+CONTRACTS_LIGO_ARRAY=("oracle-on-demand KolibriOracleAdapter")
+
+# # Ensure we have a SmartPy binary.
 if [ ! -f "$SMART_PY_CLI" ]; then
     echo "Fatal: Please install SmartPy CLI at $SMART_PY_CLI" && exit
+fi
+
+# Ensure we have a Ligo binary.
+if [ ! -x "$(command -v $LIGO_CLI)" ]; then
+    echo "Fatal: Please install Ligo CLI, https://ligolang.org/docs/intro/installation" && exit
 fi
 
 # Compile a contract.
@@ -49,6 +59,34 @@ function processContract {
     # TODO(keefertaylor): This is pretty brittle. Consider if we should migrate to Makefile or find a better way.
     cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_0_contract.tz" $CONTRACT_OUT || cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_1_contract.tz" $CONTRACT_OUT || cp "$OUT_DIR/${CONTRACT_NAME}/step_000_cont_2_contract.tz" $CONTRACT_OUT 
     echo ">>> Written to ${CONTRACT_OUT}"
+
+   
+}
+
+# Compile a ligo contract.
+# Args <contract name, ex: oracle-on-demand> <module, ex: KolibriOracleAdapter>
+function processContractLigo {
+    CONTRACT_NAME=$1
+    OUT_DIR=$2
+    CONTRACT_IN="${CONTRACT_NAME}.jsligo"
+    CONTRACT_OUT="${CONTRACT_NAME}.tz"
+
+    echo ">> Processing ${CONTRACT_NAME}"
+
+    # Ensure file exists.
+    if [ ! -f "$CONTRACT_IN" ]; then
+        echo "Fatal: $CONTRACT_IN not found. Running from wrong dir?" && exit
+    fi
+
+    # Test
+    echo ">>> [1 / 3] Testing ${CONTRACT_NAME} "
+    $LIGO_CLI run test $CONTRACT_IN
+    echo ">>> Done"
+
+    echo ">>> [2 / 3] Compiling ${CONTRACT_NAME}"
+    $LIGO_CLI compile contract $CONTRACT_IN $INVOCATION -o $CONTRACT_OUT
+    echo ">>> Done."
+    echo ">>> Written to ${CONTRACT_OUT}"
 }
 
 echo "> [1 / 3] Unit Testing and Compiling Contracts."
@@ -56,6 +94,13 @@ rm -rf $OUT_DIR
 for i in ${!CONTRACTS_ARRAY[@]}; do
     echo ">> [$((i + 1)) / ${#CONTRACTS_ARRAY[@]}] Processing ${CONTRACTS_ARRAY[$i]}"
     processContract ${CONTRACTS_ARRAY[$i]} ${INVOCATION_ARRAY[$i]} $OUT_DIR
+    echo ">> Done."
+    echo ""
+done
+for i in ${!CONTRACTS_LIGO_ARRAY[@]}; do
+    set -- ${CONTRACTS_LIGO_ARRAY[$i]}
+    echo ">> [$((i + 1)) / ${#CONTRACTS_LIGO_ARRAY[@]}] Processing $1"
+    processContractLigo $1 $2
     echo ">> Done."
     echo ""
 done

--- a/smart_contracts/oracle-on-demand.jsligo
+++ b/smart_contracts/oracle-on-demand.jsligo
@@ -1,0 +1,463 @@
+// -------------------------------------
+// Test mocks the Kolibri Oracle Adapter
+// -------------------------------------
+// #region
+export namespace Mocks {
+
+    // This is a mock callback receiver
+    // It is used to test the adapter response as a callback contract
+    //    which accepts a single nat as a parameter
+    export namespace FakeCallbackReceiver {
+        export type storage = nat;
+
+        type @return = [list<operation>, storage];
+
+        //  Disallow direct transfers.
+        @entry
+        function @default(_: unit, s: storage): @return {
+          Assert.Error.assert(Tezos.get_amount() == 0mutez, "DONT_SEND_TEZOS");
+          return [[], s]
+        }
+        // Callback which receives a single nat and writes it to the contract storage
+        @entry
+        function receivePriceCallback(value: nat, _s: storage): @return {
+            return [[], value]
+        }
+        // Additional view just for easyness of looking into the contract storage
+        @view
+        function getPrice(_:unit, s: storage): nat {
+            return s;
+        }
+    }
+    // This is a mock of Ubinetic on-demand oracle
+    export namespace FakeOnDemandOracle {
+        type priceType = @layout("comb") {
+            price: nat;
+            last_update_timestamp: timestamp; 
+        };
+
+        export type storage = {
+            prices: big_map<string, priceType>;
+        };
+
+        type @return = [list<operation>, storage];
+
+        type updateParam = @layout("comb") {
+            asset: string;
+            price: nat;
+            updatedAt: timestamp;
+        };
+        // Target view which used to retrieve price from the oracle
+        @view
+        function get_price_with_timestamp(asset: string, s: storage): priceType {
+            return match(Big_map.find_opt (asset, s.prices)) {
+                when(Some(value)): value;
+                when(None): failwith("No value.")
+            };
+        }
+        // Update price enrtypoint just for testing purposes
+        @entry
+        function updatePrice(param: updateParam, s: storage): @return {
+            const priceEntry: priceType = { 
+                price: param.price, 
+                last_update_timestamp: param.updatedAt 
+            };
+            Big_map.update(param.asset, Some(priceEntry), s.prices);
+            return [[], s]
+        }
+    }
+}
+// #endregion
+// -------------------------------------
+
+
+namespace ErrorCodes {
+  // -----------
+  // Error codes
+  // NOTE see: ./common/errors.py for full list of error codes
+  // -----------
+  // #region
+  export const amount_not_allowed = "15";
+  export const not_oracle = "3";
+  export const not_governor = "4";
+  export const stale_data = "17";
+  // #endregion
+  // -----------
+}
+
+namespace Utils {
+  // -----
+  // Utils
+  // -----
+  // #region
+  // Empty list of operations constant
+  export const no_operations: list<operation> = [];
+  // Disallows transfers of tez to the contract
+  @inline
+  export const non_tez_operation = (_: unit): unit => 
+    Assert.Error.assert(Tezos.get_amount() == 0mutez, ErrorCodes.amount_not_allowed);
+  // Asserts that the caller is the governor
+  @inline
+  export const only_governor = (governor: address): unit => 
+    Assert.Error.assert(Tezos.get_sender() == governor, ErrorCodes.not_governor);
+  // #endregion
+  // -----
+}
+
+namespace UbineticOracleUtils {
+  // -----------------------------------
+  // Ubinetic oracle constants and types
+  // -----------------------------------
+  // #region
+  // Asset code which is used to retrieve price
+  const asset_code = "XTZUSDT";
+  // Oracle view response type
+  type oracleResponse = @layout("comb"){ 
+    price: nat;
+    last_update_timestamp: timestamp;
+  };
+  // #endregion
+  // -----------------------------------
+  
+  // Retrieve price from oracle
+  @inline
+  export function retrieveXTZtoUSDTPrice(oracleContract: address, delay: nat): nat {
+    // Retrieve data from oracle view
+    const response: oracleResponse = Option.value_with_error(
+      ErrorCodes.not_oracle, // If asked contract has not view which fits request parameters.
+      Tezos.call_view(
+        "get_price_with_timestamp", 
+        asset_code, 
+        oracleContract
+      )
+    );
+    // Assert data is recent. Checks if response timestamp is not older than delay in seconds.
+    Assert.Error.assert(
+      response.last_update_timestamp >= Tezos.get_now() - int(delay), 
+      ErrorCodes.stale_data
+    );
+    return response.price;
+  }
+}
+
+namespace KolibriUtils {
+  // -------------------------
+  // Kolibri utility constants
+  // -------------------------
+  // #region
+  export const mutez_to_kolibri_conversion = 1000000000000n;
+  // #endregion
+  // -------------------------
+}
+
+
+export namespace KolibriOracleAdapter {
+  // ----------------------------
+  // Storage Data and Return type
+  // ----------------------------
+  // #region
+  export type storage = {
+    oracleProxyContractAddress : address,
+    maxDataDelaySec            : nat,
+    governorContractAddress    : address,
+  };
+  type @return = [list<operation>, storage];
+  // #endregion
+  // ----------------------------
+
+  // ----------
+  // Governance 
+  // ----------
+  // #region
+
+  //  Update the max data delay.
+  //  Parameters:
+  //    newMaxDataDelaySec The amount of seconds of maximum possible delay of data timestamp.
+  @entry
+  function setMaxDataDelaySec(newMaxDataDelaySec: nat, s: storage): @return {
+    // Verify there is no tez in transfer
+    Utils.non_tez_operation();
+    // Verify that the caller is the governor
+    Utils.only_governor(s.governorContractAddress);
+    return [
+      Utils.no_operations, // No any additional calls
+      {
+        ...s, 
+        maxDataDelaySec: newMaxDataDelaySec // Update max data delay in storage
+      }
+    ];
+  };
+
+  //  Update the governor contract.
+  //  Parameters:
+  //    newGovernorContractAddress The address of new Governance contract.
+  @entry
+  function setGovernorContract(newGovernorContractAddress: address, s: storage): @return {
+    // Verify there is no tez in transfer
+    Utils.non_tez_operation();
+    // Verify that the caller is the governor
+    Utils.only_governor(s.governorContractAddress);
+    return [
+      Utils.no_operations, // No any additional calls
+      {
+        ...s, 
+        governorContractAddress: newGovernorContractAddress // Update governor address in storage
+      }
+    ];
+  };
+  // #endregion
+  // ----------
+
+  // ----------------
+  // Public Interface
+  // ----------------
+  // #region
+  
+  //  Retrieve the price of the XTZ-USDT pair.
+  //  Parameters:
+  //    callback: A callback to call with the result. Parameter to callback is a single nat.
+  @entry
+  function getXtzUsdRate(callback: contract<nat>, s: storage): @return {
+    // Verify there is no tez in transfer
+    Utils.non_tez_operation();
+    // Get and validate correctness of the price
+    const priceValue = UbineticOracleUtils.retrieveXTZtoUSDTPrice(
+      s.oracleProxyContractAddress, 
+      s.maxDataDelaySec
+    );
+    // Convert price to Kolibri precision
+    const callbackResult: nat = priceValue * KolibriUtils.mutez_to_kolibri_conversion;
+    return [
+      // Call client callback with prepared result
+      [Tezos.Next.Operation.transaction(callbackResult, 0mutez, callback)], 
+      s
+    ];
+  };
+
+  //  Disallow direct transfers.
+  @entry
+  function @default(_: unit, s: storage): @return {
+    // Verify there is no tez in transfer
+    Utils.non_tez_operation();
+    // Nothing will happen on default
+    return [Utils.no_operations, s]
+  }
+  // #endregion
+  // ----------------
+}
+
+// ---------------
+// Test Constants
+// ---------------
+// #region
+const xtzValue = 2310000n;
+const mockedOracle = contract_of(Mocks.FakeOnDemandOracle);
+const oracleStorage: Mocks.FakeOnDemandOracle.storage = {
+    prices: Big_map.literal([
+      ["XTZUSDT", {price: xtzValue, last_update_timestamp: Tezos.get_now()}],
+    ])
+  };
+const mockedCallbackReceiver = contract_of(Mocks.FakeCallbackReceiver);
+const callbackStorage : Mocks.FakeCallbackReceiver.storage = 0n;
+const adapter = contract_of(KolibriOracleAdapter);
+
+const admin_account = Test.Next.Account.address(0n);
+const user_account = Test.Next.Account.address(1n);
+
+
+// #endregion
+
+// --------------
+// Test Functions
+// --------------
+// #region
+
+// -------------
+// getXtzUsdRate
+// -------------
+function test_with_amount(): unit {
+  Test.Next.IO.log("getXtzUsdRate - fails when called with an amount");
+  const fakeOracle = Test.Next.Originate.contract(
+    mockedOracle, 
+    oracleStorage, 
+    0mutez
+  );
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: Test.Next.Typed_address.to_address(fakeOracle.taddr),
+    maxDataDelaySec: 999999n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const callbackContract = Test.Next.Originate.contract(
+    mockedCallbackReceiver,
+    callbackStorage, 
+    0mutez
+  );
+
+  const callback: contract<nat> = Test.Next.Typed_address.get_entrypoint("receivePriceCallback", callbackContract.taddr);
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("getXtzUsdRate", adapterContract.taddr), callback, 1tez);
+  match(result) {
+    when(Fail(_x)): Test.Next.IO.log("[Success] Failed as expected");
+    when(Success(_s)): failwith("[Fail] This should not succeed")
+  };
+}
+
+function test_retrieve(): unit {
+  Test.Next.IO.log("getXtzUsdRate - retrieves correct value");
+  const fakeOracle = Test.Next.Originate.contract(
+    mockedOracle, 
+    oracleStorage, 
+    0mutez
+  );
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: Test.Next.Typed_address.to_address(fakeOracle.taddr),
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const callbackContract = Test.Next.Originate.contract(
+    mockedCallbackReceiver,
+    callbackStorage, 
+    0mutez
+  );
+
+  const callback: contract<nat> = Test.Next.Typed_address.get_entrypoint("receivePriceCallback", callbackContract.taddr);
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("getXtzUsdRate", adapterContract.taddr), callback, 0mutez);
+  match(result) {
+    when(Fail(_x)): failwith("[Fail] This should not fail");
+    when(Success(_s)): Test.Next.IO.log("[Success] Succeed as expected");
+  };
+  const expectedValue = xtzValue * KolibriUtils.mutez_to_kolibri_conversion;
+  return Assert.assert(Test.Next.Typed_address.get_storage(callbackContract.taddr) == expectedValue);
+}
+
+// -------
+// default
+// -------
+function test_default(): unit {
+  Test.Next.IO.log("default - fails when called with an amount");
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: user_account, // we don't care here
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("default", adapterContract.taddr), unit, 1mutez);
+  match(result) {
+    when(Fail(_x)): Test.Next.IO.log("[Success] Failed as expected");
+    when(Success(_s)): failwith("[Fail] This should not succeed")
+  };
+}
+
+// ------------------
+// setMaxDataDelaySec
+// ------------------
+function test_governor_set_delay(): unit {
+  Test.Next.IO.log("setMaxDataDelaySec - succeeds when called by governor");
+  Test.Next.State.set_source(admin_account);
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: user_account,
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const newDelay = 1n;
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("setMaxDataDelaySec", adapterContract.taddr), newDelay, 0mutez);
+ match(result) {
+    when(Fail(_x)): failwith("[Fail] This should not fail");
+    when(Success(_s)): Test.Next.IO.log("[Success] Succeed as expected");
+  };
+  return Assert.assert(Test.Next.Typed_address.get_storage(adapterContract.taddr).maxDataDelaySec == newDelay);
+}
+
+function test_not_governor_set_delay(): unit {
+  Test.Next.IO.log("setMaxDataDelaySec - fails when not called by governor");
+  Test.Next.State.set_source(user_account);
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: user_account,
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("setMaxDataDelaySec", adapterContract.taddr), 0n, 0mutez);
+  match(result) {
+    when(Fail(_x)): Test.Next.IO.log("[Success] Failed as expected");
+    when(Success(_s)): failwith("[Fail] This should not succeed")
+  };
+}
+
+// -------------------
+// setGovernorContract
+// -------------------
+function test_governor_set_governor(): unit {
+  Test.Next.IO.log("setGovernorContract - succeeds when called by governor");
+  Test.Next.State.set_source(admin_account);
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: user_account,
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const newGovernor = user_account;
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("setGovernorContract", adapterContract.taddr), newGovernor, 0mutez);
+  match(result) {
+    when(Fail(_x)): failwith("[Fail] This should not fail");
+    when(Success(_s)): Test.Next.IO.log("[Success] Succeed as expected");
+  };
+  return Assert.assert(Test.Next.Typed_address.get_storage(adapterContract.taddr).governorContractAddress == newGovernor);
+}
+
+function test_not_governor_set_governor(): unit {
+  Test.Next.IO.log("setGovernorContract - fails when not called by governor");
+  Test.Next.State.set_source(user_account);
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: user_account,
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("setGovernorContract", adapterContract.taddr), user_account, 0mutez);
+  match(result) {
+    when(Fail(_x)): Test.Next.IO.log("[Success] Failed as expected");
+    when(Success(_s)): failwith("[Fail] This should not succeed")
+  };
+}
+// #endregion
+
+// #region Run Tests
+const test1 = test_default();
+const test2 = test_retrieve();
+const test3 = test_governor_set_delay();
+const test4 = test_governor_set_governor();
+const test5 = test_with_amount();
+const test6 = test_not_governor_set_delay();
+const test7 = test_not_governor_set_governor();
+// #endregion

--- a/smart_contracts/oracle-on-demand.jsligo
+++ b/smart_contracts/oracle-on-demand.jsligo
@@ -90,6 +90,8 @@ namespace Utils {
   // Utils
   // -----
   // #region
+  // Zero timestamp for casting
+  export const zeroTimestamp: timestamp = 0 as timestamp;
   // Empty list of operations constant
   export const no_operations: list<operation> = [];
   // Disallows transfers of tez to the contract
@@ -118,6 +120,13 @@ namespace UbineticOracleUtils {
   };
   // #endregion
   // -----------------------------------
+
+  @inline
+  function timestampFromMilliseconds(tsAsMilliseconds: timestamp): timestamp {
+    const tsAsIntWoMilliseconds: int = (tsAsMilliseconds - Utils.zeroTimestamp) / 1000;
+    const ts: timestamp = tsAsIntWoMilliseconds + Utils.zeroTimestamp;
+    return ts;
+  }
   
   // Retrieve price from oracle
   @inline
@@ -133,7 +142,7 @@ namespace UbineticOracleUtils {
     );
     // Assert data is recent. Checks if response timestamp is not older than delay in seconds.
     Assert.Error.assert(
-      response.last_update_timestamp >= Tezos.get_now() - int(delay), 
+      timestampFromMilliseconds(response.last_update_timestamp) >= Tezos.get_now() - int(delay), 
       ErrorCodes.stale_data
     );
     return response.price;
@@ -251,10 +260,22 @@ export namespace KolibriOracleAdapter {
 // ---------------
 // #region
 const xtzValue = 2310000n;
+const twoDays = 86_400 * 2
+// NOTE: the Ubinetic oracle store the timestamps in non-standard way, with milliseconds. 
+// Highlighted here: https://discord.com/channels/790468417844412456/790469864934211604/1314628665669058630
+// Issue opened here: https://github.com/ecadlabs/taquito/issues/3093
+const nowInMilliseconds = ((Tezos.get_now() - Utils.zeroTimestamp) * 1000) + Utils.zeroTimestamp;
+const twoDaysEarlierInMilliseconds = ((Tezos.get_now() - twoDays) - Utils.zeroTimestamp) * 1000 + Utils.zeroTimestamp;
 const mockedOracle = contract_of(Mocks.FakeOnDemandOracle);
 const oracleStorage: Mocks.FakeOnDemandOracle.storage = {
     prices: Big_map.literal([
-      ["XTZUSDT", {price: xtzValue, last_update_timestamp: Tezos.get_now()}],
+      ["XTZUSDT", {price: xtzValue, last_update_timestamp: nowInMilliseconds}],
+    ])
+  };
+
+const oracleStorageOutdated: Mocks.FakeOnDemandOracle.storage = {
+    prices: Big_map.literal([
+      ["XTZUSDT", {price: xtzValue, last_update_timestamp: twoDaysEarlierInMilliseconds}],
     ])
   };
 const mockedCallbackReceiver = contract_of(Mocks.FakeCallbackReceiver);
@@ -339,6 +360,36 @@ function test_retrieve(): unit {
   return Assert.assert(Test.Next.Typed_address.get_storage(callbackContract.taddr) == expectedValue);
 }
 
+function test_outdated_retrieve(): unit {
+  Test.Next.IO.log("getXtzUsdRate - failed to retrieve outdated value");
+  const fakeOracle = Test.Next.Originate.contract(
+    mockedOracle, 
+    oracleStorageOutdated, 
+    0mutez
+  );
+  const adapterStorage: KolibriOracleAdapter.storage = {
+    oracleProxyContractAddress: Test.Next.Typed_address.to_address(fakeOracle.taddr),
+    maxDataDelaySec: 60n * 30n,
+    governorContractAddress: admin_account,
+  };
+  const adapterContract = Test.Next.Originate.contract(
+    adapter,
+    adapterStorage, 
+    0mutez
+  );
+  const callbackContract = Test.Next.Originate.contract(
+    mockedCallbackReceiver,
+    callbackStorage, 
+    0mutez
+  );
+
+  const callback: contract<nat> = Test.Next.Typed_address.get_entrypoint("receivePriceCallback", callbackContract.taddr);
+  const result = Test.Next.Contract.transfer(Test.Next.Typed_address.get_entrypoint("getXtzUsdRate", adapterContract.taddr), callback, 0mutez);
+  match(result) {
+    when(Fail(_x)): Test.Next.IO.log("[Success] Failed as expected");
+    when(Success(_s)): failwith("[Fail] This should not succeed")
+  };
+}
 // -------
 // default
 // -------
@@ -460,4 +511,5 @@ const test4 = test_governor_set_governor();
 const test5 = test_with_amount();
 const test6 = test_not_governor_set_delay();
 const test7 = test_not_governor_set_governor();
+const test8 = test_outdated_retrieve();
 // #endregion

--- a/smart_contracts/oracle-on-demand.tz
+++ b/smart_contracts/oracle-on-demand.tz
@@ -7,7 +7,7 @@
           (nat %maxDataDelaySec)
           (address %governorContractAddress)) ;
   code { PUSH string "15" ;
-         PUSH string "4" ;
+         PUSH timestamp 0 ;
          NIL operation ;
          DIG 3 ;
          UNPAIR ;
@@ -23,9 +23,8 @@
              SWAP }
            { IF_LEFT
                { DIG 2 ;
+                 DROP ;
                  DIG 3 ;
-                 DROP 2 ;
-                 DIG 2 ;
                  PUSH mutez 0 ;
                  AMOUNT ;
                  COMPARE ;
@@ -45,8 +44,16 @@
                  INT ;
                  NOW ;
                  SUB ;
-                 DUP 3 ;
+                 PUSH int 1000 ;
+                 DUP 7 ;
+                 DUP 5 ;
                  CDR ;
+                 SUB ;
+                 EDIV ;
+                 IF_NONE { PUSH string "DIV by 0" ; FAILWITH } {} ;
+                 CAR ;
+                 DIG 6 ;
+                 ADD ;
                  COMPARE ;
                  GE ;
                  IF { DROP } { FAILWITH } ;
@@ -61,14 +68,16 @@
                  DIG 4 ;
                  TRANSFER_TOKENS ;
                  CONS }
-               { IF_LEFT
-                   { DIG 4 ;
+               { DIG 3 ;
+                 DROP ;
+                 IF_LEFT
+                   { DIG 3 ;
                      PUSH mutez 0 ;
                      AMOUNT ;
                      COMPARE ;
                      EQ ;
                      IF { DROP } { FAILWITH } ;
-                     DIG 3 ;
+                     PUSH string "4" ;
                      DUP 3 ;
                      GET 4 ;
                      SENDER ;
@@ -76,13 +85,13 @@
                      EQ ;
                      IF { DROP } { FAILWITH } ;
                      UPDATE 4 }
-                   { DIG 4 ;
+                   { DIG 3 ;
                      PUSH mutez 0 ;
                      AMOUNT ;
                      COMPARE ;
                      EQ ;
                      IF { DROP } { FAILWITH } ;
-                     DIG 3 ;
+                     PUSH string "4" ;
                      DUP 3 ;
                      GET 4 ;
                      SENDER ;

--- a/smart_contracts/oracle-on-demand.tz
+++ b/smart_contracts/oracle-on-demand.tz
@@ -1,0 +1,95 @@
+{ parameter
+    (or (unit %default)
+        (or (contract %getXtzUsdRate nat)
+            (or (address %setGovernorContract) (nat %setMaxDataDelaySec)))) ;
+  storage
+    (pair (address %oracleProxyContractAddress)
+          (nat %maxDataDelaySec)
+          (address %governorContractAddress)) ;
+  code { PUSH string "15" ;
+         PUSH string "4" ;
+         NIL operation ;
+         DIG 3 ;
+         UNPAIR ;
+         IF_LEFT
+           { DIG 3 ;
+             DROP 2 ;
+             DIG 2 ;
+             PUSH mutez 0 ;
+             AMOUNT ;
+             COMPARE ;
+             EQ ;
+             IF { DROP } { FAILWITH } ;
+             SWAP }
+           { IF_LEFT
+               { DIG 2 ;
+                 DIG 3 ;
+                 DROP 2 ;
+                 DIG 2 ;
+                 PUSH mutez 0 ;
+                 AMOUNT ;
+                 COMPARE ;
+                 EQ ;
+                 IF { DROP } { FAILWITH } ;
+                 DUP 2 ;
+                 CAR ;
+                 PUSH string "XTZUSDT" ;
+                 VIEW "get_price_with_timestamp"
+                      (pair (nat %price) (timestamp %last_update_timestamp)) ;
+                 PUSH string "3" ;
+                 SWAP ;
+                 IF_NONE { FAILWITH } { SWAP ; DROP } ;
+                 PUSH string "17" ;
+                 DUP 4 ;
+                 GET 3 ;
+                 INT ;
+                 NOW ;
+                 SUB ;
+                 DUP 3 ;
+                 CDR ;
+                 COMPARE ;
+                 GE ;
+                 IF { DROP } { FAILWITH } ;
+                 PUSH nat 1000000000000 ;
+                 SWAP ;
+                 CAR ;
+                 MUL ;
+                 DIG 2 ;
+                 NIL operation ;
+                 DIG 3 ;
+                 PUSH mutez 0 ;
+                 DIG 4 ;
+                 TRANSFER_TOKENS ;
+                 CONS }
+               { IF_LEFT
+                   { DIG 4 ;
+                     PUSH mutez 0 ;
+                     AMOUNT ;
+                     COMPARE ;
+                     EQ ;
+                     IF { DROP } { FAILWITH } ;
+                     DIG 3 ;
+                     DUP 3 ;
+                     GET 4 ;
+                     SENDER ;
+                     COMPARE ;
+                     EQ ;
+                     IF { DROP } { FAILWITH } ;
+                     UPDATE 4 }
+                   { DIG 4 ;
+                     PUSH mutez 0 ;
+                     AMOUNT ;
+                     COMPARE ;
+                     EQ ;
+                     IF { DROP } { FAILWITH } ;
+                     DIG 3 ;
+                     DUP 3 ;
+                     GET 4 ;
+                     SENDER ;
+                     COMPARE ;
+                     EQ ;
+                     IF { DROP } { FAILWITH } ;
+                     UPDATE 3 } ;
+                 SWAP } } ;
+         PAIR } }
+


### PR DESCRIPTION
This PR adds the new oracle implementation, which points to Ubinetic On Demand oracle proxy for getting price.
It is urgent fix of oracle outage issue. Harbinger oracle is no more up-to-date with prices and looks like there will not any future updates on it.

The contract and tests were written using the latest LIGO version (JsLIGO). The only difference against the original SmartPy implementation is throwing errors, which now throw the same Error codes but as `string` type instead of `nat/int`, as I think will not cause huge problems for service. 